### PR TITLE
Added send coffee script to node repl function

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -41,5 +41,7 @@ nmap <C-c><C-c> vip<C-c><C-c>
 " Ctrl-C, Ctrl-S will compile coffee code and then send results to the
 " connected screen
 vmap <C-c><C-s> "ry:call Send_Coffee_to_NodeRepl_Screen(@r)<CR>
+nmap <C-c><C-s> vip<C-c><C-s>
+
 
 nmap <C-c>v :call Screen_Vars()<CR>


### PR DESCRIPTION
The reason being, that the node repl is much better than the coffee repl especially when it comes to providing info concerning objects methods and properties (which is what I care most about when using a repl).

So the added function allows to select coffee-script code, compiles it into javascript and sends it to the connected screen. That way I can have a node repl running which only understands javascript.

All previous functionality is not affected. E.g. Ctrl-C still works as before, but Ctrl-S compiles first.

BTW - love your plugin (use it every day now - with my extension) and will blog about it.
