### PR TITLE
Fix missing !exists

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -53,7 +53,9 @@ endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Public interface
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-let g:slime_option = "tmux"
+if !exists("g:slime_option")
+    let g:slime_option = "tmux"
+end
 
 let s:slime_muxes = {
             \ "tmux":{"fn_config":"TmuxConfig", "fn_send":"TmuxSend", "config_var":"slime_tmux"},


### PR DESCRIPTION
The `!exists` variable check was missing when tmux was set as the default
slime option, so it was always set to tmux even if the user set it to
"screen" in his/her vimrc.

(I do find `screen` to be a more sensible default than `tmux`, though, given that this plugin was originally created for `screen`. But that's just my $0.02)
