### PR TITLE
Remove empty lines from Python code

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,3 +1,4 @@
 function! _EscapeText_python(text)
-  return substitute(a:text, "\n", "", "g")
+  let no_empty_lines = substitute(a:text, '\n\s*\ze\n', "", "g")
+  return substitute(no_empty_lines, "\n", "", "g")
 endfunction


### PR DESCRIPTION
When sending  Python classes to the REPL, empty line breaks will break the code. Methods of a class are interpreted as separate code chunks by the REPL if there is even a single line break between them.

This pull request removes all lines with only white space characters in them during escaping.

This has small usability issue thou. In multi-line sends we should add one extra line break to the end of the snippet. But my Vim script-fu falls short here...
