### PR TITLE
Add IPython cpaste support

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,6 +1,10 @@
 
 function! _EscapeText_python(text)
-  let no_empty_lines = substitute(a:text, '\n\s*\ze\n', "", "g")
-  return substitute(no_empty_lines, "\n", "", "g")
+  if exists('g:slime_python_ipython')
+    return "%cpaste\n".a:text."--\n"
+  else
+    let no_empty_lines = substitute(a:text, '\n\s*\ze\n', "", "g")
+    return substitute(no_empty_lines, "\n", "", "g")
+  end
 endfunction
 


### PR DESCRIPTION
Setting `g:slime_python_ipython` allows IPython users to use the `%cpaste` feature.
