### PR TITLE
More robust handling of selections for ocaml

### DIFF
--- a/ftplugin/ocaml/slime.vim
+++ b/ftplugin/ocaml/slime.vim
@@ -1,8 +1,8 @@
 function! _EscapeText_ocaml(text)
-    " We only append ';;' to text if text 
-    if match(a:text,';;\s*$') > -1
-        return [a:text]
+    let trimmed = substitute(a:text, '\_s*$', '', '')
+    if match(trimmed,';;\n*$') > -1
+        return [trimmed,"\n"]
     else 
-        return [a:text,";;\n"]
+        return [trimmed,";;\n"]
     endif
 endfunction


### PR DESCRIPTION
- ;; is now only appended if it's not already there. (some old scripts and toplevel directives still have ;;
  littered in the code)
- the ocaml toplevel is a little finnicky with trailing whitespace so we make sure to remove it 
