### PR TITLE
g:slime_default_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ you sent over.  If this behavior is undesired one alternative is to use a tempor
 
     let g:slime_paste_file = tempname()
 
+If you do not want vim-slime to prompt for every buffer, you can set a default configuration
+
+    let g:slime_default_config = {"socket_name": "default", "target_pane": "1"}
+
+If this default config is not appropriate for a given buffer, you can call `:SlimeConfig` 
+to reset it.
+
 Configuration (whimrepl)
 ------------------------
 

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -123,10 +123,18 @@ function! s:_EscapeText(text)
   end
 endfunction
 
-function! s:SlimeSendOp(type, ...) abort
+function! s:SlimeGetConfig()
   if !exists("b:slime_config")
-    call s:SlimeDispatch('Config')
+    if exists("g:slime_default_config")
+      let b:slime_config = g:slime_default_config
+    else
+      call s:SlimeDispatch('Config')
+    end
   end
+endfunction
+
+function! s:SlimeSendOp(type, ...) abort
+  call s:SlimeGetConfig()
 
   let sel_save = &selection
   let &selection = "inclusive"
@@ -151,9 +159,7 @@ function! s:SlimeSendOp(type, ...) abort
 endfunction
 
 function! s:SlimeSendRange() range abort
-  if !exists("b:slime_config")
-    call s:SlimeDispatch('Config')
-  end
+  call s:SlimeGetConfig()
 
   let rv = getreg('"')
   let rt = getregtype('"')


### PR DESCRIPTION
Having a default config allows me to do something like:

```
  # in .vimrc
  let g:slime_target = "tmux"
  let g:slime_default_config = {"socket_name": "default", "target_pane": "1"}

  # in my .bashrc
  function hack-django { 
    TERM=xterm-256color
    source ./virtualenv/bin/activate
    tmux new-session "vim $*" \; splitw -v -l 10 'python ./manage.py shell'   \; select-pane -U
  }
```

As I've created the tmux in a consistent way, the pane will always be #1, so it's much nicer not to have to answer the question again each time.
