### PR TITLE
Make SlimeSendLines honour g:slime_default_config.

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -169,9 +169,7 @@ function! s:SlimeSendRange() range abort
 endfunction
 
 function! s:SlimeSendLines(count) abort
-  if !exists("b:slime_config")
-    call s:SlimeDispatch('Config')
-  end
+  call s:SlimeGetConfig()
 
   let rv = getreg('"')
   let rt = getregtype('"')


### PR DESCRIPTION
The merge that added g:slime_default_config added SlimeGetConfig calls
to SlimeSendOp and SlimeSendRange, but not to SlimeSendLines. Thus the
latter did not use defaults if they were set. This change corrects that.
