### PR TITLE
Remove buffer when sending text with tmux.

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -53,7 +53,7 @@ function! s:TmuxSend(config, text)
     call s:WritePasteFile(a:text)
     call system(l:prefix . " load-buffer " . g:slime_paste_file)
   end
-  call system(l:prefix . " paste-buffer -t " . shellescape(a:config["target_pane"]))
+  call system(l:prefix . " paste-buffer -d -t " . shellescape(a:config["target_pane"]))
 endfunction
 
 function! s:TmuxPaneNames(A,L,P)


### PR DESCRIPTION
Tmux keeps its buffers as a stack. Without this patch, every time a selection
is sent to tmux, one buffer will be added. By adding the "-d" option to 'tmux
paste-buffer', the buffer is released.
