### PR TITLE
Haskell fixes

### DIFF
--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -41,11 +41,14 @@ function! Indent_lines(lines)
     let l:indent = Get_indent_string()
     let l:i = 1
     let l:len = len(l:lines)
+    let l:seen_where = 0
     while l:i < l:len
         " only indent if not starting with space
-        let l:has_guard = match(l:lines[l:i], "\\ \\+|")
+        let l:has_guard = match(l:lines[l:i], "\\ \\+|") == 0
+        let l:has_where = match(l:lines[l:i], "\\ \\+where") == 0
+        let l:seen_where = l:seen_where || l:has_where
 
-        if l:lines[l:i][0] != " " || l:has_guard == 0
+        if l:lines[l:i][0] != " " || l:has_guard || l:seen_where
             let l:lines[l:i] = l:indent . l:lines[l:i]
         endif
         let l:i += 1


### PR DESCRIPTION
Added support for function guards and `where` clauses. 

The following code: 

```
initials :: String -> String -> String
initials first last = "Mr. " ++ [f, l]
    where (f:_) = first
          (l:_) = last

maximum' :: (Ord a) => [a] -> a
maximum' []       = error "Empty list"
maximum' (x:[])   = x
maximum' (x:xs)  
    | x > y     = x
    | otherwise = y
    where y = maximum' xs
```

Produced these commands, before the fix:

```
:{
let initials :: String -> String -> String
    initials first last = "Mr. " ++ [f, l]
    where (f:_) = first
          (l:_) = last

    maximum' :: (Ord a) => [a] -> a
    maximum' []       = error "Empty list"
    maximum' (x:[])   = x
    maximum' (x:xs)  
    | x > y     = x
    | otherwise = y
    where y = maximum' xs
:}
```

And after the fix:

```
:{
let initials :: String -> String -> String
    initials first last = "Mr. " ++ [f, l]
        where (f:_) = first
              (l:_) = last

    maximum' :: (Ord a) => [a] -> a
    maximum' []       = error "Empty list"
    maximum' (x:[])   = x
    maximum' (x:xs)  
        | x > y     = x
        | otherwise = y
        where y = maximum' xs
:}
```
