### PR TITLE
Preserve cursor position when sending a line or paragraph

### DIFF
--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -137,6 +137,10 @@ g:slime_paste_file	Used to transfer data from vim to GNU Screen or tmux.
 			used. Setting this explicitly can work around some
 			occasional portability issues.
 			whimrepl does not require or support this setting.
+						*g:slime_preserve_curpos*
+g:slime_preserve_curpos	Set to non zero value to preserve cursor position when
+			sending a line or paragraph. Default is zero.
+
 
 Mappings~
 

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -12,6 +12,10 @@ if !exists("g:slime_target")
   let g:slime_target = "screen"
 end
 
+if !exists("g:slime_preserve_curpos")
+  let g:slime_preserve_curpos = 0
+end
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -156,6 +160,8 @@ function! s:SlimeSendOp(type, ...) abort
 
   let &selection = sel_save
   call setreg('"', rv, rt)
+
+  call s:SlimeRestoreCurPos()
 endfunction
 
 function! s:SlimeSendRange() range abort
@@ -176,6 +182,18 @@ function! s:SlimeSendLines(count) abort
   exe "norm! " . a:count . "yy"
   call s:SlimeSend(@")
   call setreg('"', rv, rt)
+endfunction
+
+function! s:SlimeStoreCurPos()
+  if g:slime_preserve_curpos == 1
+    let s:cur = getcurpos()
+  endif
+endfunction
+
+function! s:SlimeRestoreCurPos()
+  if g:slime_preserve_curpos == 1
+    call setpos('.', s:cur)
+  endif
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -214,7 +232,7 @@ command -bar -nargs=0 SlimeConfig call s:SlimeConfig()
 command -range -bar -nargs=0 SlimeSend <line1>,<line2>call s:SlimeSendRange()
 command -nargs=+ SlimeSend1 call s:SlimeSend(<q-args> . "\r")
 
-noremap <SID>Operator :<c-u>set opfunc=<SID>SlimeSendOp<cr>g@
+noremap <SID>Operator :<c-u>call <SID>SlimeStoreCurPos()<cr>:set opfunc=<SID>SlimeSendOp<cr>g@
 
 noremap <unique> <script> <silent> <Plug>SlimeRegionSend :<c-u>call <SID>SlimeSendOp(visualmode(), 1)<cr>
 noremap <unique> <script> <silent> <Plug>SlimeLineSend :<c-u>call <SID>SlimeSendLines(v:count1)<cr>


### PR DESCRIPTION
When you send a line or a paragraph the cursor moves to the beginning, which is OK, most of the time. But sometimes you may want to test something and not lose track of the current line (especially if it's a function definition spanning multiple lines, or a long line).

I added `g:slime_preserve_curpos` to define if it should preserve the cursor position, because I'm not sure if this is something that you'd want as a default. It makes the whole "sending a paragraph" too silent.

But I'm using vim-slime for livecoding with [Tidal](http://yaxu.org/tidal/) and, in that context, this is a really good feature :)

What do you think?