### PR TITLE
Add documentation for slime_python_ipython

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,4 +164,12 @@ for a certain file extension. For instance, I have:
 
 in `~/.vim/ftdetect/hss.vim`.
 
+### Python
 
+Sending code to an interactive Python session is tricky business due to Python's indentation-sensitive nature.
+Perfectly valid code which executes when run from a file may fail with a `SyntaxError` when pasted into the CPython interpreter.
+
+[IPython](http://ipython.org/) has a `%cpaste` "magic function" that allows for error-free pasting.
+In order for vim-slime to make use of this feature for Python buffers, you need to set the corresponding variable in your .vimrc:
+
+    let g:slime_python_ipython = 1


### PR DESCRIPTION
Seems like people are finding the `slime_python_ipython` setting useful, so I've finally added it to the README.

I also snuck in a change to the nesting in the README that I think is reasonable. Let me know if you would prefer to keep it the way it was.
