### PR TITLE
Fixes prompting for config even though g:slime_default_config exists

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -127,8 +127,9 @@ function! s:SlimeGetConfig()
   if !exists("b:slime_config")
     if exists("g:slime_default_config")
       let b:slime_config = g:slime_default_config
+    else
+      call s:SlimeDispatch('Config')
     end
-    call s:SlimeDispatch('Config')
   end
 endfunction
 


### PR DESCRIPTION
Although `let g:slime_default_config = {"socket_name": "default", "target_pane": "1"}` is set in my `~/.vimrc` the plugin keeps on prompting me for a config. This patch fixes this behavior.