### PR TITLE
SlimeRunCell

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -8,3 +8,4 @@ function! _EscapeText_python(text)
   end
 endfunction
 
+let g:slime_cell_delimiter = "##"

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -208,7 +208,7 @@ endfunction
 function! s:SlimeRunCell() abort
     " Run a cell delimited by g:cell_delimiter
     call s:SlimeGetConfig()
-    execute ":?" . g:slime_cell_delimiter . "?,/" . g.slime_cell_delimiter . "/y a"
+    execute "silent :?" . g:slime_cell_delimiter . "?;/" . g:slime_cell_delimiter . "/y a"
     "silent :?##?;/##/y a
     ']
     execute "normal! j"

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -205,6 +205,16 @@ function! s:SlimeDispatch(name, ...)
   return call("s:" . target . a:name, a:000)
 endfunction
 
+function! s:SlimeRunCell() abort
+    " Run a cell delimited by g:cell_delimiter
+    call s:SlimeGetConfig()
+    execute ":?" . g:slime_cell_delimiter . "?,/" . g.slime_cell_delimiter . "/y a"
+    "silent :?##?;/##/y a
+    ']
+    execute "normal! j"
+    call s:SlimeSend(@a)
+endfunction
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Setup key bindings
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -212,6 +222,7 @@ endfunction
 command -bar -nargs=0 SlimeConfig call s:SlimeConfig()
 command -range -bar -nargs=0 SlimeSend <line1>,<line2>call s:SlimeSendRange()
 command -nargs=+ SlimeSend1 call s:SlimeSend(<q-args> . "\r")
+command -nargs=0 SlimeRunCell call s:SlimeRunCell()
 
 noremap <SID>Operator :<c-u>set opfunc=<SID>SlimeSendOp<cr>g@
 
@@ -220,8 +231,14 @@ noremap <unique> <script> <silent> <Plug>SlimeLineSend :<c-u>call <SID>SlimeSend
 noremap <unique> <script> <silent> <Plug>SlimeMotionSend <SID>Operator
 noremap <unique> <script> <silent> <Plug>SlimeParagraphSend <SID>Operatorip
 noremap <unique> <script> <silent> <Plug>SlimeConfig :<c-u>SlimeConfig<cr>
+noremap <unique> <script> <silent> <Plug>SlimeRunCell :<c-u>call <SID>SlimeRunCell()<cr>
 
 if !exists("g:slime_no_mappings") || !g:slime_no_mappings
+  "exists("g:slime_cell_delimiter") 
+  if !hasmapto('<Plug>SlimeRunCell', 'n')
+      nmap <c-c><Enter> <Plug>SlimeRunCell
+  endif
+
   if !hasmapto('<Plug>SlimeRegionSend', 'x')
     xmap <c-c><c-c> <Plug>SlimeRegionSend
   endif


### PR DESCRIPTION
In Matlab we delimit code blocks with `%%` and run them with `Ctrl+Enter` while inside that block. This PR adds the same functionality to vim-slime with the difference that the user can define her own `g:slime_cell_delimiter` (using each languages comment char). After running the cell, the cursor is moved to the next one. You can run a cell with `<c-c><Enter>`. The user has to define `g:slime_cell_delimiter` to use this. 

This was inspired by the work in [julienr/vim-cellmode](https://github.com/julienr/vim-cellmode) . But there they hard coded the cell delimiter to work with Python.

ToDo:
- [ ] Add ⍐ and ⍗ cell navigation keys 
- [ ] Update docs about this
- [ ] If there is no ending `g:slime_cell_delimiter`, SlimeRunCell should run everything till the last line.
- [ ] Automatically define `g:slime_cell_delimiter` as a function of the language of the current buffer.
