### PR TITLE
Adjusting behaviour to only use cpaste magic on multi-line code trans…

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,6 +1,6 @@
 
 function! _EscapeText_python(text)
-  if exists('g:slime_python_ipython')
+  if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
     return "%cpaste\n".a:text."--\n"
   else
     let no_empty_lines = substitute(a:text, '\n\s*\ze\n', "", "g")


### PR DESCRIPTION
…mission.

A small change so that, when sending a single line of text, don't use cpaste. Useful if you want to send a single line (with a potential logic error in it) to ipython, then use up/history in ipython to play with the line. Without this, every line is sent with %cpaste magic, which makes the code unrecoverable within the ipython session.