### PR TITLE
adding slime_dont_ask_default config option which bypasses config prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ If you want vim-slime to prefill the prompt answers, you can set a default confi
 
     let g:slime_default_config = {"socket_name": "default", "target_pane": "1"}
 
+If you want vim-slime to bypass the prompt and use the specified default configuration options, set the `slime_dont_ask_default` option to `"true"`
+
+    let g:slime_default_config = {"socket_name": "default", "target_pane": "1", "slime_dont_ask_default": "true"}
+
 If this default config is not appropriate for a given buffer, you can call `:SlimeConfig`
 to reset it.
 

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -127,8 +127,12 @@ function! s:SlimeGetConfig()
   if !exists("b:slime_config")
     if exists("g:slime_default_config")
       let b:slime_config = g:slime_default_config
+      if get(b:slime_config, 'slime_dont_ask_default', 'false') != 'true'
+        call s:SlimeDispatch('Config')
+      end
+    else
+      call s:SlimeDispatch('Config')
     end
-    call s:SlimeDispatch('Config')
   end
 endfunction
 


### PR DESCRIPTION
Per issues #62, #69 (opened by me) and pull request #70, it seems like this is an option people want. (My approach was directly inspired by @jpalardy's comments in PR #70.)

It might make sense to validate the presence of the required options for the various multiplexers inside their respective *Config functions, but I thought this was enough to get the conversation started.