### PR TITLE
Matlab eval wrap

### DIFF
--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -142,7 +142,7 @@ g:slime_paste_file	Used to transfer data from vim to GNU Screen or tmux.
 g:slime_python_ipython	Set to non zero value when using IPython to enable
 			%cpaste support in Python buffers.
 
-                                                g:slime_matlab_eval
+                                                *g:slime_matlab_eval*
 g:slime_matlab_eval     Set to non zero value when using matlab to enable
                         pasting inside eval() function. Allows to distinguish between the
                         sent code and an output it produces for easier

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -142,6 +142,12 @@ g:slime_paste_file	Used to transfer data from vim to GNU Screen or tmux.
 g:slime_python_ipython	Set to non zero value when using IPython to enable
 			%cpaste support in Python buffers.
 
+                                                g:slime_matlab_eval
+g:slime_matlab_eval     Set to non zero value when using matlab to enable
+                        pasting inside eval() function. Allows to distinguish between the
+                        sent code and an output it produces for easier
+                        spotting of errors. 
+
 Mappings~
 
 Slime's default mappings can be overridden by setting up mappings in your

--- a/ftplugin/matlab/slime.vim
+++ b/ftplugin/matlab/slime.vim
@@ -1,10 +1,13 @@
 function! _EscapeText_matlab(text)
   if exists('g:slime_matlab_eval')
-    let text_escap = substitute(a:text, '''', '''''', 'g')
+    let text_trimm = substitute(a:text, '\n\s\+', '\n', 'g')
+    let text_escap = substitute(text_trimm, '''', '''''', 'g')
+    let text_escap = substitute(text_escap, '%', '%%', 'g')
+    let text_escap = substitute(text_escap, '\', '\\\', 'g')
     let text_split = split(text_escap, "\n")
-    let text_quote = map(copy(text_split), '"''" . v:val . "'',..."')
-    let text_evals = ['eval([...'] + text_quote + [']);']
-    return join(text_evals, "\n")."\n"
+    let text_quote = map(copy(text_split), '"''" . v:val . "\\n'',..."')
+    let text_print = ['eval(sprintf([...'] + text_quote + [''''']));']
+    return join(text_print, "\n")."\n"
   else
     return a:text
   end

--- a/ftplugin/matlab/slime.vim
+++ b/ftplugin/matlab/slime.vim
@@ -1,0 +1,12 @@
+function! _EscapeText_matlab(text)
+  if exists('g:slime_matlab_eval')
+    let text_escap = substitute(a:text, '''', '''''', 'g')
+    let text_split = split(text_escap, "\n")
+    let text_quote = map(copy(text_split), '"''" . v:val . "'',..."')
+    let text_evals = ['eval([...'] + text_quote + [']);']
+    return join(text_evals, "\n")."\n"
+  else
+    return a:text
+  end
+endfunction
+


### PR DESCRIPTION
When sending a code to matlab, it is often hard to distinguish between the code sent and the output produced. Furthermore, if sending a long list of instuctions, errors produced by the first ones quickly get burried under the rest of the code pasted. Additionally, there is no visual distinction between the errors and the output in terminal as compared to the matlab gui. Finally, when part of the code produced errors, you may want to stop the execution and not to produce any additional output.

Here is a simple solution for aforementioned problems that sends the code wrapped around in eval and sprintf. Behaviour can be toggled by setting / unsetting g:slime_matlab_eval. It supports escaping single quotes and printf-style formatted strings.