### PR TITLE
adding `main` to not_prefixable_keywords in ftplugin/haskell/slime.vim

### DIFF
--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -1,4 +1,4 @@
-let s:not_prefixable_keywords = [ "import", "data", "instance", "class", "{-#", "type", "case", "do", "let", "default", "newtype", "foreign", "--"]
+let s:not_prefixable_keywords = [ "import", "data", "instance", "class", "{-#", "type", "case", "do", "let", "default", "newtype", "foreign", "--", "main"]
 
 " Remove '>' on line beginning in literate haskell
 function! Remove_initial_gt(lines)


### PR DESCRIPTION
Addresses the following portion of #66: 

> I know there's a Haskell ftplugin file that tries to add lets to the appropriate lines, and it does pretty well, but if I put main on its own line and send it, or if I try to :SlimeSend1 main to run the main function, e.g., I can't get it to send without the prefix.

![2015-11-09-004337_1600x900_scrot](https://cloud.githubusercontent.com/assets/289949/11026642/f320246c-867a-11e5-90ac-3dac8875531b.png)
