### PR TITLE
Fixed issue where python code was not being executed when sent to python interpreter.

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -4,7 +4,7 @@ function! _EscapeText_python(text)
     return "%cpaste\n".a:text."--\n"
   else
     let no_empty_lines = substitute(a:text, '\n\s*\ze\n', "", "g")
-    return substitute(no_empty_lines, "\n", "", "g")
+    return substitute(no_empty_lines, "\n", "", "g")."\n"
   end
 endfunction
 


### PR DESCRIPTION
I was having issues with code sent to the python interpreter getting stuck after for loops or if's. It needed an extra newline for the interpreter to see that the code block had finished and to go ahead and execute. 

The change is on line 7 where I simply append a newline. The extra "\n" fixes the issue so that the code sent to the python interpreter is executed.