### PR TITLE
Haskell: Avoid incorrect let prefixing

### DIFF
--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -1,5 +1,3 @@
-let s:not_prefixable_keywords = [ "import", "data", "instance", "class", "{-#", "type", "case", "do", "let", "default", "newtype", "foreign", "--", "main"]
-
 " Remove '>' on line beginning in literate haskell
 function! Remove_initial_gt(lines)
     return map(copy(a:lines), "substitute(v:val, '^>[ \t]*', '', 'g')")
@@ -9,12 +7,10 @@ endfunction
 function! Perhaps_prepend_let(lines)
     if len(a:lines) > 0
         let l:lines = a:lines
-        let l:word  = split(l:lines[0], " ")[0]
-        let l:char  = strpart(l:word, 0, 1)
+        let l:line  = l:lines[0]
 
-        " if first line is prefixable, prefix with let
-        " (taken from Cumino code)
-        if index(s:not_prefixable_keywords, l:word) < 0 && l:char != ":"
+        " Prepend let if the line is an assignment
+        if l:line =~ "="
             let l:lines[0] = "let " . l:lines[0]
         endif
 

--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -10,7 +10,7 @@ function! Perhaps_prepend_let(lines)
         let l:line  = l:lines[0]
 
         " Prepend let if the line is an assignment
-        if l:line =~ "="
+        if l:line =~ "=" || l:line =~ "::"
             let l:lines[0] = "let " . l:lines[0]
         endif
 


### PR DESCRIPTION
I've altered the logic that determines whether a statement should be prefixed with `let ` so that it only applies to statements that are likely to be assignments, as is desirable.

Previously this feature resulted in incorrect statements being sent to GHCi.

i.e. `1 + 1` became `let 1 + 1`

Fixes https://github.com/jpalardy/vim-slime/issues/85