### PR TITLE
Fixing the double semi-colon problem for ocaml when using vim-slime with utop

### DIFF
--- a/ftplugin/ocaml/slime.vim
+++ b/ftplugin/ocaml/slime.vim
@@ -3,6 +3,6 @@ function! _EscapeText_ocaml(text)
     if match(trimmed,';;\n*$') > -1
         return [trimmed,"\n"]
     else 
-        return [trimmed,";;\n"]
+        return [trimmed . ";;","\n"]
     endif
 endfunction


### PR DESCRIPTION
While the ocaml settings work fine with the default ocaml REPL, the separation of the text and the added ";;\n" produces unpleasant behavior under utop (an enhanced and popular toplevel for OCaml) : 

- there is no newline between sent code and utop output (readability)
- worst, errors messages are not visible (somehow the command is considered "closed" by the newline, or whatever).

This pull request seems to solve the problem for utop (tested by sending one line/multiple lines, with and without valid code, and with and without manually added semicolon) and to leave the behavior unchanged for the default ocaml REPL.
It also seems more natural since the returned array would now be exactly the same no matter the double semicolon was already in the code or not. In the current version, one has `["mycode;;","\n"] ` in the first case and `["mycode",";;\n"]` in the second.