### PR TITLE
Add support for Conemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Context for [SLIME](https://en.wikipedia.org/wiki/SLIME):
     Vim-slime is a humble attempt at getting _some_ of these features into Vim.
     It works with any REPL and isn't tied to Lisp.
 
-Grab some text and send it to a [GNU Screen](http://www.gnu.org/software/screen/) / [tmux](http://tmux.sourceforge.net/) / [whimrepl](https://github.com/malyn/lein-whimrepl) session.
+Grab some text and send it to a [GNU Screen](http://www.gnu.org/software/screen/) / [tmux](http://tmux.sourceforge.net/) / [whimrepl](https://github.com/malyn/lein-whimrepl) / [ConEmu](http://conemu.github.io/) session.
 
-    VIM ---(text)---> screen / tmux / whimrepl
+    VIM ---(text)---> screen / tmux / whimrepl / ConEmu
 
 Presumably, your session contains a [REPL](http://en.wikipedia.org/wiki/REPL), maybe Clojure, R or python. If you can type text into it, vim-slime can send text to it.
 
@@ -144,6 +144,23 @@ whimrepl server name
     displays that name in its banner every time you start up an instance of
     whimrepl.
 
+### ConEmu
+
+ConEmu is *not* the default, to use it you will have to add this line to your .vimrc:
+
+    let g:slime_target = "conemu"
+
+When you invoke vim-slime for the first time, you will be prompted for more
+configuration.
+
+ConEmu console server HWND
+
+    This is what you put in the -GuiMacro flag. It will be "0" if you didn't put
+    anything, adressing the active tab/split of the first found ConEmu window.
+
+By default the windows clipboard is used to pass the text to ConEmu. If you
+experience issues with this, make sure the `conemuc` executable is in your
+`path`.
 
 Advanced Configuration
 ----------------------
@@ -190,4 +207,3 @@ might tweak the text without explicit configuration:
   * python / ipython -- [README](ftplugin/python)
   * scala
   * sml
-

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -79,7 +79,9 @@ endfunction
 
 function! s:ConemuSend(config, text)
   let l:prefix = "conemuc -guimacro:" . a:config["HWND"]
-  " use STDIN unless configured to use a file
+  " use the selection register to send text to ConEmu using the windows
+  " clipboard (see help gui-clipboard)
+  " save the current selection to restore it after send
   let tmp = @*
   let @* = a:text
   call system(l:prefix . " print")
@@ -87,10 +89,12 @@ function! s:ConemuSend(config, text)
 endfunction
 
 function! s:ConemuConfig() abort
+  " set destination for send commands, as specified in
+  " http://conemu.github.io/en/GuiMacro.html#Command_line
   if !exists("b:slime_config")
+    " defaults to the active tab/split of the first found ConEmu window
     let b:slime_config = {"HWND": "0"}
   end
-
   let b:slime_config["HWND"] = input("Console server HWND: ", b:slime_config["HWND"])
 endfunction
 

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -74,6 +74,27 @@ function! s:TmuxConfig() abort
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Conemu
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+function! s:ConemuSend(config, text)
+  let l:prefix = "conemuc -guimacro:" . a:config["HWND"]
+  " use STDIN unless configured to use a file
+  let tmp = @*
+  let @* = a:text
+  call system(l:prefix . " print")
+  let @* = tmp
+endfunction
+
+function! s:ConemuConfig() abort
+  if !exists("b:slime_config")
+    let b:slime_config = {"HWND": "0"}
+  end
+
+  let b:slime_config["HWND"] = input("Console server HWND: ", b:slime_config["HWND"])
+endfunction
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " whimrepl
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 


### PR DESCRIPTION
[ConEmu](http://conemu.github.io/) is a windows console emulator with many features, which is also the base for the [cmder](http://cmder.net/) console emulator for windows.
Support for ConEmu enables one to benefit from vim-slime under windows, without requiring cygwin or msys.

Use conemuc to send text to the selected conemu console (default to the
active tab of the first found conemu window).
Use the windows clipboard to send text, so store and restore the
previous value.