### PR TITLE
use getpos('.') instead of getcurpos() for old vim

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -218,7 +218,13 @@ endfunction
 
 function! s:SlimeStoreCurPos()
   if g:slime_preserve_curpos == 1
-    let s:cur = getcurpos()
+    let has_getcurpos = exists("*getcurpos")
+    if has_getcurpos
+      " getcurpos() doesn't exist before 7.4.313.
+      let s:cur = getcurpos()
+    else
+      let s:cur = getpos('.')
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
the getcurpos function doesn't exist before 7.4.313, so work around the
issue if it is not available.