### PR TITLE
python escape text: add new empty line between indented and non-indented lines

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -4,7 +4,9 @@ function! _EscapeText_python(text)
     return "%cpaste\n".a:text."--\n"
   else
     let no_empty_lines = substitute(a:text, '\n\s*\ze\n', "", "g")
-    return substitute(no_empty_lines, "\n", "", "g")."\n"
+    let except_pat = '\(elif\|else\|except\|finally\)\@!'
+    let add_eol_pat = '\n\s[^\n]\+\n\zs\ze'.except_pat.'\S'
+    return substitute(no_empty_lines, add_eol_pat, "\n", "g")."\n"
   end
 endfunction
 


### PR DESCRIPTION
Those extra lines close code blocks --- e.g. a class definition with multiple function definitions. Note: empty lines are already removed (except from the beginning of the text).

We should not add a new line between lines, where the non-indented line begins with a specific keyword, e.g. "elif", as those are continuations of an already opened code block, and it should not be closed by a mistakenly added new line.

Tested with Cygwin 2.5.1 (x86_64), Tmux 2.2, Vim 7.4.1816, and Python 2.7.10 by opening each of the following library source code files, selecting the whole file, and sending them over to the python interpreter: re.py, os.py, ast.py, bdb.py, csv.py, fnmatch.py, glob.py, gzip.py, string.py --- no stdin errors encountered.