### PR TITLE
python escape text: dedent a code block starting at non-zero level

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -3,7 +3,8 @@ function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
     return "%cpaste\n".a:text."--\n"
   else
-    let no_empty_lines = substitute(a:text, '\(^\|\n\)\zs\s*\n\+\ze', "", "g")
+    let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
+    let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")
     let except_pat = '\(elif\|else\|except\|finally\)\@!'
     let add_eol_pat = '\n\s[^\n]\+\n\zs\ze\('.except_pat.'\S\|$\)'
     return substitute(no_empty_lines, add_eol_pat, "\n", "g")

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -5,8 +5,8 @@ function! _EscapeText_python(text)
   else
     let no_empty_lines = substitute(a:text, '\(^\|\n\)\zs\s*\n\+\ze', "", "g")
     let except_pat = '\(elif\|else\|except\|finally\)\@!'
-    let add_eol_pat = '\n\s[^\n]\+\n\zs\ze'.except_pat.'\S'
-    return substitute(no_empty_lines, add_eol_pat, "\n", "g")."\n"
+    let add_eol_pat = '\n\s[^\n]\+\n\zs\ze\('.except_pat.'\S\|$\)'
+    return substitute(no_empty_lines, add_eol_pat, "\n", "g")
   end
 endfunction
 

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -5,9 +5,11 @@ function! _EscapeText_python(text)
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")
+    let dedent_pat = '\(^\|\n\)\zs'.matchstr(no_empty_lines, '^\s*')
+    let dedented_lines = substitute(no_empty_lines, dedent_pat, "", "g")
     let except_pat = '\(elif\|else\|except\|finally\)\@!'
     let add_eol_pat = '\n\s[^\n]\+\n\zs\ze\('.except_pat.'\S\|$\)'
-    return substitute(no_empty_lines, add_eol_pat, "\n", "g")
+    return substitute(dedented_lines, add_eol_pat, "\n", "g")
   end
 endfunction
 

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -3,7 +3,7 @@ function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
     return "%cpaste\n".a:text."--\n"
   else
-    let no_empty_lines = substitute(a:text, '\n\s*\ze\n', "", "g")
+    let no_empty_lines = substitute(a:text, '\(^\|\n\)\zs\s*\n\+\ze', "", "g")
     let except_pat = '\(elif\|else\|except\|finally\)\@!'
     let add_eol_pat = '\n\s[^\n]\+\n\zs\ze'.except_pat.'\S'
     return substitute(no_empty_lines, add_eol_pat, "\n", "g")."\n"


### PR DESCRIPTION
- More robust empty line removal (especially at the beginning of text)
- Only adding new lines at the end of text when needed
- Dedent a code block starting at non-zero level