### PR TITLE
Do not prepend "let" when sending type definitions

### DIFF
--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -3,6 +3,13 @@ function! Remove_initial_gt(lines)
     return map(copy(a:lines), "substitute(v:val, '^>[ \t]*', '', 'g')")
 endfunction
 
+function! Is_type_declaration(line)
+  let l:isNewType = a:line =~ "newtype"
+  let l:isTypeAlias = a:line =~ "type"
+  let l:isData = a:line =~ "data"
+  return l:isNewtype || l:isTypeAlias || l:isData
+endfunction
+
 " Prepend certain statements with 'let'
 function! Perhaps_prepend_let(lines)
     if len(a:lines) > 0
@@ -10,7 +17,7 @@ function! Perhaps_prepend_let(lines)
         let l:line  = l:lines[0]
 
         " Prepend let if the line is an assignment
-        if l:line =~ "=" || l:line =~ "::"
+        if (l:line =~ "=" || l:line =~ "::") && !Is_type_declaration(l:line)
             let l:lines[0] = "let " . l:lines[0]
         endif
 

--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -7,7 +7,7 @@ function! Is_type_declaration(line)
   let l:isNewType = a:line =~ "newtype"
   let l:isTypeAlias = a:line =~ "type"
   let l:isData = a:line =~ "data"
-  return l:isNewtype || l:isTypeAlias || l:isData
+  return l:isNewType || l:isTypeAlias || l:isData
 endfunction
 
 " Prepend certain statements with 'let'


### PR DESCRIPTION
Currently various type declarations will fail since `let` is prepended. This PR adds a function to check whether a line is a `newtype` declaration, a type alias, or a datatype declaration. That function is then added to `Perhaps_prepend_let`'s check so that `let` is not prepended to such declarations.

NB: This works when one presses C-c, C-c on an individual type declaration. There is more work to be done for submitting blocks or entire files