### PR TITLE
Tmux eval result in buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ tmux target pane:
             (either session name or number), the ith window and the jth pane
     "%i"    means i refers the pane's unique id
 
+#### Get Difference
+
+This is an experimental feature for putting the evaluation results back into the current vim buffer, analogous to supplying a prefix argument for evaluation in SLIME or Geiser. Enable with:
+
+    let g:slime_take_snapshot = 1
+
+`<C-c><C-d>` will put the difference between what was in the target buffer before the last time text was sent (`<C-c><C-c>`), and the current state.
+
+The following parameters are configurable:
+
+* `g:slime_snapshot_file` (defaults to `~/.slime_snapshot`): file to hold the contents of target buffer pre-evaluation
+* `g:slime_current_file` (defaults to `~/.slime_current`): file to hold the current contents of target buffer
+* `g:slime_default_config["difference_trim"]` (defaults to 1): the number of lines ignored from the tail of the difference (the last lines in the target buffer will most likely be the interpreter/shell prompt or newlines, which can be discarded).
+
+WARNING: Enabling this feature will cause the history of the target pane to be erased every time `<C-c><C-c>` is used.
 
 ### whimrepl
 

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -77,7 +77,7 @@ function! s:TmuxConfig() abort
   if !exists("b:slime_config")
     let b:slime_config = {"socket_name": "default", "target_pane": ":"}
 	if exists('g:slime_take_snapshot')
-      let b:slime_config = {"socket_name": "default", "target_pane": ":", "snapshot_offset": 1}
+      let b:slime_config = {"socket_name": "default", "target_pane": ":", "difference_trim": 1}
 	endif
   end
   let b:slime_config["socket_name"] = input("tmux socket name: ", b:slime_config["socket_name"])
@@ -86,7 +86,7 @@ function! s:TmuxConfig() abort
     let b:slime_config["target_pane"] = split(b:slime_config["target_pane"])[0]
   endif
   if exists('g:slime_take_snapshot')
-    let b:slime_config["snapshot_offset"] = input("tmux snapshot offset: ", b:slime_config["snapshot_offset"])
+    let b:slime_config["difference_trim"] = input("tmux difference trim: ", b:slime_config["difference_trim"])
   endif
 endfunction
 
@@ -102,7 +102,7 @@ function! s:TmuxGetDifference(config) abort
 	\let num_snapshot_lines_trimmed=$(printf "\%s" "$(< ' . g:slime_snapshot_file . ')" | wc -l);
 	\let num_diff=$(($num_current_lines_trimmed - $num_snapshot_lines_trimmed - $num_paste_lines + 1));
 	\let tail_offset=$(($num_current_lines - $num_snapshot_lines_trimmed - 1));
-	\let head_offset=$(($num_diff - ' . a:config["snapshot_offset"] . '));
+	\let head_offset=$(($num_diff - ' . a:config["difference_trim"] . '));
 	\tail -n $tail_offset ' . g:slime_current_file . ' | head -n $head_offset;'
 	execute l:difference_sh
 endfunction

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -30,6 +30,8 @@ if !exists("g:slime_current_file")
   let g:slime_current_file = "$HOME/.slime_current"
 end
 
+let s:plugin_path = expand('<sfile>:p:h')
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -91,20 +93,7 @@ function! s:TmuxConfig() abort
 endfunction
 
 function! s:TmuxGetDifference(config) abort
-    call system("tmux -L " . shellescape(a:config["socket_name"]) . " capture-pane -S -9999 -t " . shellescape(a:config["target_pane"]))
-    call system("tmux -L " . shellescape(a:config["socket_name"]) . " save-buffer " . g:slime_current_file)
-    call system("tmux -L " . shellescape(a:config["socket_name"]) . " delete-buffer")
-
-	let l:difference_sh = 'read! 
-	\let num_current_lines=$(wc -l ' . g:slime_current_file . ' | cut -d " " -f 1);
-	\let num_paste_lines=$(wc -l ' . g:slime_paste_file . ' | cut -d " " -f 1);
-	\let num_current_lines_trimmed=$(printf "\%s" "$(< ' . g:slime_current_file . ')" | wc -l);
-	\let num_snapshot_lines_trimmed=$(printf "\%s" "$(< ' . g:slime_snapshot_file . ')" | wc -l);
-	\let num_diff=$(($num_current_lines_trimmed - $num_snapshot_lines_trimmed - $num_paste_lines + 1));
-	\let tail_offset=$(($num_current_lines - $num_snapshot_lines_trimmed - 1));
-	\let head_offset=$(($num_diff - ' . a:config["difference_trim"] . '));
-	\tail -n $tail_offset ' . g:slime_current_file . ' | head -n $head_offset;'
-	execute l:difference_sh
+    execute "read !/bin/bash " . s:plugin_path . "/tmux_get_difference.sh " . a:config["socket_name"] . " " . a:config["target_pane"] . " " . g:slime_paste_file . " " . g:slime_current_file . " " . g:slime_snapshot_file . " " . a:config["difference_trim"]
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -76,10 +76,10 @@ endfunction
 function! s:TmuxConfig() abort
   if !exists("b:slime_config")
     let b:slime_config = {"socket_name": "default", "target_pane": ":"}
-	if exists('g:slime_take_snapshot')
-      let b:slime_config = {"socket_name": "default", "target_pane": ":", "difference_trim": 1}
-	endif
-  end
+  endif
+  if exists("g:slime_take_snapshot") && !has_key(b:slime_config, "difference_trim")
+    let b:slime_config["difference_trim"] = 1
+  endif
   let b:slime_config["socket_name"] = input("tmux socket name: ", b:slime_config["socket_name"])
   let b:slime_config["target_pane"] = input("tmux target pane: ", b:slime_config["target_pane"], "custom,<SNR>" . s:SID() . "_TmuxPaneNames")
   if b:slime_config["target_pane"] =~ '\s\+'

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -21,6 +21,15 @@ if !exists("g:slime_paste_file")
   let g:slime_paste_file = "$HOME/.slime_paste"
 end
 
+" for get_snapshot
+if !exists("g:slime_snapshot_file")
+  let g:slime_snapshot_file = "$HOME/.slime_snapshot"
+end
+
+if !exists("g:slime_current_file")
+  let g:slime_current_file = "$HOME/.slime_current"
+end
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -49,6 +58,11 @@ endfunction
 
 function! s:TmuxSend(config, text)
   call s:WritePasteFile(a:text)
+  if exists('g:slime_take_snapshot')
+    call system("tmux -L " . shellescape(a:config["socket_name"]) . " clear-history -t " . shellescape(a:config["target_pane"]))
+    call system("tmux -L " . shellescape(a:config["socket_name"]) . " capture-pane -b snapshot -t " . shellescape(a:config["target_pane"]))
+    call system("tmux -L " . shellescape(a:config["socket_name"]) . " save-buffer -b snapshot " . g:slime_snapshot_file)
+  endif
   call system("tmux -L " . shellescape(a:config["socket_name"]) . " load-buffer " . g:slime_paste_file)
   call system("tmux -L " . shellescape(a:config["socket_name"]) . " paste-buffer -d -t " . shellescape(a:config["target_pane"]))
 endfunction
@@ -61,12 +75,34 @@ endfunction
 function! s:TmuxConfig() abort
   if !exists("b:slime_config")
     let b:slime_config = {"socket_name": "default", "target_pane": ":"}
+	if exists('g:slime_take_snapshot')
+      let b:slime_config = {"socket_name": "default", "target_pane": ":", "snapshot_offset": 1}
+	endif
   end
   let b:slime_config["socket_name"] = input("tmux socket name: ", b:slime_config["socket_name"])
   let b:slime_config["target_pane"] = input("tmux target pane: ", b:slime_config["target_pane"], "custom,<SNR>" . s:SID() . "_TmuxPaneNames")
   if b:slime_config["target_pane"] =~ '\s\+'
     let b:slime_config["target_pane"] = split(b:slime_config["target_pane"])[0]
   endif
+  if exists('g:slime_take_snapshot')
+    let b:slime_config["snapshot_offset"] = input("tmux snapshot offset: ", b:slime_config["snapshot_offset"])
+  endif
+endfunction
+
+function! s:TmuxGetDifference(config) abort
+    call system("tmux -L " . shellescape(a:config["socket_name"]) . " capture-pane -S - -b current -t " . shellescape(a:config["target_pane"]))
+    call system("tmux -L " . shellescape(a:config["socket_name"]) . " save-buffer -b current " . g:slime_current_file)
+
+	let l:difference_sh = 'read! 
+	\let num_current_lines=$(wc -l ' . g:slime_current_file . ' | cut -d " " -f 1);
+	\let num_paste_lines=$(wc -l ' . g:slime_paste_file . ' | cut -d " " -f 1);
+	\let num_current_lines_trimmed=$(printf "\%s" "$(< ' . g:slime_current_file . ')" | wc -l);
+	\let num_snapshot_lines_trimmed=$(printf "\%s" "$(< ' . g:slime_snapshot_file . ')" | wc -l);
+	\let num_diff=$(($num_current_lines_trimmed - $num_snapshot_lines_trimmed - $num_paste_lines + 1));
+	\let tail_offset=$(($num_current_lines - $num_snapshot_lines_trimmed - 1));
+	\let head_offset=$(($num_diff - ' . a:config["snapshot_offset"] . '));
+	\tail -n $tail_offset ' . g:slime_current_file . ' | head -n $head_offset;'
+	execute l:difference_sh
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -226,6 +262,9 @@ function! s:SlimeRestoreCurPos()
   endif
 endfunction
 
+function! s:SlimeGetDifference() abort
+    call s:SlimeDispatch('GetDifference', b:slime_config)
+endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Public interface
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -248,6 +287,10 @@ function! s:SlimeConfig() abort
   call inputrestore()
 endfunction
 
+function! s:SlimeGetDifference() abort
+	call s:SlimeDispatch('GetDifference', b:slime_config)
+endfunction
+
 " delegation
 function! s:SlimeDispatch(name, ...)
   let target = substitute(tolower(g:slime_target), '\(.\)', '\u\1', '') " Capitalize
@@ -259,6 +302,7 @@ endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 command -bar -nargs=0 SlimeConfig call s:SlimeConfig()
+command -bar -nargs=0 SlimeGetDifference call s:SlimeGetDifference()
 command -range -bar -nargs=0 SlimeSend <line1>,<line2>call s:SlimeSendRange()
 command -nargs=+ SlimeSend1 call s:SlimeSend(<q-args> . "\r")
 command -nargs=+ SlimeSend0 call s:SlimeSend(<args>)
@@ -270,6 +314,7 @@ noremap <unique> <script> <silent> <Plug>SlimeLineSend :<c-u>call <SID>SlimeSend
 noremap <unique> <script> <silent> <Plug>SlimeMotionSend <SID>Operator
 noremap <unique> <script> <silent> <Plug>SlimeParagraphSend <SID>Operatorip
 noremap <unique> <script> <silent> <Plug>SlimeConfig :<c-u>SlimeConfig<cr>
+noremap <unique> <script> <silent> <Plug>SlimeGetDifference :call <SID>SlimeGetDifference()<cr>
 
 if !exists("g:slime_no_mappings") || !g:slime_no_mappings
   if !hasmapto('<Plug>SlimeRegionSend', 'x')
@@ -280,8 +325,19 @@ if !exists("g:slime_no_mappings") || !g:slime_no_mappings
     nmap <c-c><c-c> <Plug>SlimeParagraphSend
   endif
 
+  if !hasmapto('<Plug>SlimeParagraphSend', 'n')
+    nmap <c-c><c-c> <Plug>SlimeParagraphSend
+  endif
+
+  if !hasmapto('<Plug>SlimeParagraphGetDifference', 'n')
+    nmap <c-c><c-d> <Plug>SlimeGetDifference
+  endif
+
   if !hasmapto('<Plug>SlimeConfig', 'n')
     nmap <c-c>v <Plug>SlimeConfig
   endif
-endif
 
+  if !hasmapto('<Plug>SlimeGetDifference', 'n')
+    nmap <c-c><c-d> <Plug>SlimeGetDifference
+  endif
+endif

--- a/plugin/tmux_get_difference.sh
+++ b/plugin/tmux_get_difference.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ $# -ne 6 ]; then
+    echo $0: usage: get_difference.sh socket_name target_pane slime_paste_file slime_current_file slime_snapshot_file difference_trim
+    exit 1
+fi
+
+socket_name=$1
+target_pane=$2
+slime_paste_file=$3
+slime_current_file=$4
+slime_snapshot_file=$5
+difference_trim=$6
+
+tmux -L $socket_name capture-pane -S -9999 -t $target_pane;
+tmux -L $socket_name save-buffer $slime_current_file;
+tmux -L $socket_name delete-buffer;
+
+num_current_lines=$(wc -l $slime_current_file | awk '{print $1}');
+num_paste_lines=$(wc -l $slime_paste_file | awk '{print $1}');
+num_current_lines_trimmed=$(printf "%s" "$(<$slime_current_file)" | wc -l);
+num_snapshot_lines_trimmed=$(printf "%s" "$(<$slime_snapshot_file)" | wc -l);
+
+num_diff=$(($num_current_lines_trimmed - $num_snapshot_lines_trimmed - $num_paste_lines + 1));
+tail_offset=$(($num_current_lines - $num_snapshot_lines_trimmed - 1));
+head_offset=$(($num_diff - $difference_trim));
+
+tail -n $tail_offset $slime_current_file | head -n $head_offset;


### PR DESCRIPTION
Hi, I had go addressing this [issue](https://github.com/jpalardy/vim-slime/issues/90) I brought up a while back, regarding putting the results of the evaluation back into vim with a keybinding. I've had a play around with the feature and it's working nicely on tmux 1.8 and 2.2, using the snapshot idea you mentioned. The only kludge is erasing the history of the pane (get around the edge condition of the max history length being reached) when `<C-c><C-c>` is pressed. Let me know what you think!

Eddie
