### PR TITLE
Break python escape into pieces for IPython

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,7 +1,7 @@
 
 function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return "%cpaste\n".a:text."--\n"
+    return ["%cpaste\n", a:text."--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")


### PR DESCRIPTION
Fix for #109

Sending `%cpaste` separately from the code seems to fix this for me. I did a quick test against IPython 4.2.1 (as well as 5) to make sure this didn't break things for IPython 4 users.