### PR TITLE
Add note about zero-indexing in tmux windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ tmux socket name:
 
 tmux target pane:
 
+Note that all of these ordinals are 0-indexed by default.
+
     ":"     means current window, current pane (a reasonable default)
     ":i"    means the ith window, current pane
     ":i.j"  means the ith window, jth pane


### PR DESCRIPTION
This took me a little trial and error to figure out, especially because vim-slime hangs without an error message if you enter an invalid value.