### PR TITLE
change python escape to fix IPython 5.1 output

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,7 +1,7 @@
 
 function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return ["%cpaste\n", a:text."--\n"]
+    return ["%cpaste\n", a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")


### PR DESCRIPTION
When sending text to IPython 5.1, the colons that should be leading every line of code are all printed at the end of the input. The Python output (`Out[]:` or the result of a `print`) is printed after these columns without any newline. 

![slime_ipython_before](https://cloud.githubusercontent.com/assets/9514702/19536877/2e58dea0-964e-11e6-96c1-20a81ac1ca74.png)

Not only is this output ugly, but more importantly it can become difficult to read when dealing with a large number of lines. 

The current pull request addresses this issue, resulting in a cleaner output.

![slime_ipython_after](https://cloud.githubusercontent.com/assets/9514702/19537000/9b9def3c-964e-11e6-99da-62f5213b9a90.png)
