### PR TITLE
Add quiet option to ipython %cpaste call

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,7 +1,7 @@
 
 function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return ["%cpaste\n", a:text, "--\n"]
+    return ["%cpaste -q\n", a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")


### PR DESCRIPTION
Purely cosmetic change, adding this silences the 
`Pasting code; enter '--' alone on the line to stop or use Ctrl-D.`
and
`--`
lines above and below the selected text.