### PR TITLE
Replace multiple system calls in function ScreenSend

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -1,4 +1,3 @@
-
 if exists('g:loaded_slime') || &cp || v:version < 700
   finish
 endif
@@ -27,10 +26,8 @@ end
 
 function! s:ScreenSend(config, text)
   call s:WritePasteFile(a:text)
-  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) . " -X msgwait 0")
-  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) . " -X readreg p " . g:slime_paste_file)
-  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) . " -X paste p")
-  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) . " -X msgwait 5")
+  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
+        \ " -X eval \"msgwait 0\" \"readreg p " . g:slime_paste_file . "\" \"paste p\" \"msgwait 5\"")
 endfunction
 
 function! s:ScreenSessionNames(A,L,P)


### PR DESCRIPTION
By using the eval command, Screen is run once per function call.