### PR TITLE
Update slime.vim

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -27,7 +27,13 @@ end
 function! s:ScreenSend(config, text)
   call s:WritePasteFile(a:text)
   call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
-        \ " -X eval \"msgwait 0\" \"readreg p " . g:slime_paste_file . "\" \"paste p\" \"msgwait 5\"")
+        \ " -X eval \"msgwait 0\"")
+  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
+        \ " -X eval \"readreg p " . g:slime_paste_file . "\"")
+  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
+        \ " -X paste p")
+  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
+        \ " -X eval \"msgwait 5\"")
 endfunction
 
 function! s:ScreenSessionNames(A,L,P)


### PR DESCRIPTION
When trying to run your version of slime.vim, I had one window to the left (bash), and the vim window to the right. On trying to send the simple command "ls" (or any command) from the right window to the left, it would always end up sending it to the vim window, not the bash window.

By separating out the "sendscreen" command into the four separate calls, I managed to fix this error.

I found this error to be present on:
1. macOS Sierra 10.12 with standard Mac VIM + https://github.com/FreedomBen/screen-for-OSX
2. In this Dockerfile: https://github.com/raubreywhite/docker/tree/master/dpython

(Note in the linked dockerfile I install my forked version of vim-slime. If I install your version, then the error is present).