### PR TITLE
Work with absolute path to tmux socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,12 @@ When you invoke vim-slime for the first time, you will be prompted for more conf
 
 tmux socket name:
 
-    If you started tmux with the -L flag, use that same socket name here. If you didn't put anything, the default name is "default".
+    If you started tmux with the -L or -S flag, use that same socket name or path here.
+    If you didn't put anything, the default name is "default".
+
+You can set the default, e.g. to choose the same tmux session that is running vim:
+
+    let g:slime_default_tmux_socket_name = split($TMUX, ",")[0]
 
 tmux target pane:
 
@@ -132,6 +137,9 @@ Note that all of these ordinals are 0-indexed by default.
             (either session name or number), the ith window and the jth pane
     "%i"    means i refers the pane's unique id
 
+You can set the default:
+
+    let g:slime_default_tmux_target_pane = ":.2"
 
 ### whimrepl
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,6 @@ tmux socket name:
     If you started tmux with the -L or -S flag, use that same socket name or path here.
     If you didn't put anything, the default name is "default".
 
-You can set the default, e.g. to choose the same tmux session that is running vim:
-
-    let g:slime_default_tmux_socket_name = split($TMUX, ",")[0]
-
 tmux target pane:
 
 Note that all of these ordinals are 0-indexed by default.
@@ -137,9 +133,10 @@ Note that all of these ordinals are 0-indexed by default.
             (either session name or number), the ith window and the jth pane
     "%i"    means i refers the pane's unique id
 
-You can set the default:
+You can configure the defaults for these options. If you generally run vim in
+a split tmux window with a REPL in the other pane:
 
-    let g:slime_default_tmux_target_pane = ":.2"
+    let g:slime_default_config = {"socket_name": split($TMUX, ",")[0], "target_pane": ":.2"}
 
 ### whimrepl
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ you sent over.
 
 When you invoke vim-slime for the first time, you will be prompted for more configuration.
 
-tmux socket name:
+tmux socket name or absolute path:
 
     If you started tmux with the -L or -S flag, use that same socket name or path here.
     If you didn't put anything, the default name is "default".

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -20,6 +20,14 @@ if !exists("g:slime_paste_file")
   let g:slime_paste_file = expand("$HOME/.slime_paste")
 end
 
+if !exists("g:slime_default_tmux_socket_name")
+  let g:slime_default_tmux_socket_name = "default"
+end
+
+if !exists("g:slime_default_tmux_target_pane")
+  let g:slime_default_tmux_target_pane = ":"
+end
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -52,22 +60,13 @@ endfunction
 " Tmux
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-function! s:TmuxDefaultSocket()
-  " The socket path is the first value in the comma-separated list of $TMUX.
-  return empty($TMUX) ? "default" : split($TMUX, ",")[0]
-endfunction
-
-function! s:IsAbsolute(path)
-  " Case sensitivity does not matter here, but let's follow good practice.
-  " TODO: Make this cross-platform. Windows supports tmux as of mid-2016.
-  return a:path[0] ==? "/"
-endfunction
-
 function! s:TmuxCommand(config, args)
   let l:socket = a:config["socket_name"]
-  " Use tmux -S for an absolute path to the socket.
-  " Use tmux -L for a relative path to the socket in tmux's temporary directory.
-  let l:socket_option = s:IsAbsolute(l:socket) ? "-S" : "-L"
+  " For an absolute path to the socket, use tmux -S.
+  " For a relative path to the socket in tmux's temporary directory, use tmux -L.
+  " Case sensitivity does not matter here, but let's follow good practice.
+  " TODO: Make this cross-platform. Windows supports tmux as of mid-2016.
+  let l:socket_option = l:socket[0] ==? "/" ? "-S" : "-L"
   return system("tmux " . l:socket_option . " " . shellescape(l:socket) . " " . a:args)
 endfunction
 
@@ -84,7 +83,7 @@ endfunction
 
 function! s:TmuxConfig() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"socket_name": s:TmuxDefaultSocket(), "target_pane": ":.2"}
+    let b:slime_config = {"socket_name": g:slime_default_tmux_socket_name, "target_pane": g:slime_default_tmux_target_pane}
   end
   let b:slime_config["socket_name"] = input("tmux socket name or absolute path: ", b:slime_config["socket_name"])
   let b:slime_config["target_pane"] = input("tmux target pane: ", b:slime_config["target_pane"], "custom,<SNR>" . s:SID() . "_TmuxPaneNames")

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -20,14 +20,6 @@ if !exists("g:slime_paste_file")
   let g:slime_paste_file = expand("$HOME/.slime_paste")
 end
 
-if !exists("g:slime_default_tmux_socket_name")
-  let g:slime_default_tmux_socket_name = "default"
-end
-
-if !exists("g:slime_default_tmux_target_pane")
-  let g:slime_default_tmux_target_pane = ":"
-end
-
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -83,7 +75,7 @@ endfunction
 
 function! s:TmuxConfig() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"socket_name": g:slime_default_tmux_socket_name, "target_pane": g:slime_default_tmux_target_pane}
+    let b:slime_config = {"socket_name": "default", "target_pane": ":"}
   end
   let b:slime_config["socket_name"] = input("tmux socket name or absolute path: ", b:slime_config["socket_name"])
   let b:slime_config["target_pane"] = input("tmux target pane: ", b:slime_config["target_pane"], "custom,<SNR>" . s:SID() . "_TmuxPaneNames")


### PR DESCRIPTION
- Pull default socket path from `$TMUX` environment variable, if it exists.
- Pass -S or -L to tmux command depending on whether the socket path is
  absolute or relative.

Closes #99