### PR TITLE
Erase the message issued by paste command immediately. No side-effect.

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -27,13 +27,10 @@ end
 function! s:ScreenSend(config, text)
   call s:WritePasteFile(a:text)
   call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
-        \ " -X eval \"msgwait 0\"")
-  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
         \ " -X eval \"readreg p " . g:slime_paste_file . "\"")
   call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
         \ " -X paste p")
-  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
-        \ " -X eval \"msgwait 5\"")
+  call system('screen -X colon "^M"')
 endfunction
 
 function! s:ScreenSessionNames(A,L,P)


### PR DESCRIPTION
As it was mentioned in #23, current approach to avoid the "Slurp X characters ..." message changes the `msgwait` set by the user. The proposed one erases that message immediately without such side effects.