### PR TITLE
136 - prevent let from being inserted before instance declaration using typeclass constraint

### DIFF
--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -17,7 +17,7 @@ function! Perhaps_prepend_let(lines)
         let l:line  = l:lines[0]
 
         " Prepend let if the line is an assignment
-        if (l:line =~ "=" || l:line =~ "::") && !Is_type_declaration(l:line)
+        if (l:line =~ "=[^>]" || l:line =~ "::") && !Is_type_declaration(l:line)
             let l:lines[0] = "let " . l:lines[0]
         endif
 


### PR DESCRIPTION
Addresses #136.

I'm open to suggestions about cleaner, more self-documenting ways of codifying this _should prepend let_ logic.