### PR TITLE
Visual Mode Preserve Cursor position after long selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ By default, vim-slime will try to restore your cursor position after it runs. If
 
     let g:slime_preserve_curpos = 0
 
-If you would like vim-slime to restore your cursor position after using Visual Mode in Vim, unset the `g:slime_preserve_curpos_sel` option:
+When selecting in Visual mode, if you would like vim-slime to restore your cursor position to the end of the selection, unset the `g:slime_preserve_curpos_sel` option:
 
     let g:slime_preserve_curpos_sel = 0
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ By default, vim-slime will try to restore your cursor position after it runs. If
 
     let g:slime_preserve_curpos = 0
 
+If you would like vim-slime to restore your cursor position after using Visual Mode in Vim, unset the `g:slime_preserve_curpos_sel` option:
+
+    let g:slime_preserve_curpos_sel = 0
+
 
 Language Support
 ----------------

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ By default, vim-slime will try to restore your cursor position after it runs. If
 
     let g:slime_preserve_curpos = 0
 
-When selecting in Visual mode, if you would like vim-slime to restore your cursor position to the end of the selection, unset the `g:slime_preserve_curpos_sel` option:
+When selecting mulitple lines in Visual mode, if you would like vim-slime to restore your cursor position to the bottom line of the selection, unset the `g:slime_preserve_curpos_sel` option:
 
     let g:slime_preserve_curpos_sel = 0
 

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -15,6 +15,10 @@ if !exists("g:slime_preserve_curpos")
   let g:slime_preserve_curpos = 1
 end
 
+if !exists("g:slime_preserve_curpos_sel")
+  let g:slime_preserve_curpos_sel = 1
+end
+
 " screen and tmux need a file, so set a default if not configured
 if !exists("g:slime_paste_file")
   let g:slime_paste_file = expand("$HOME/.slime_paste")
@@ -200,7 +204,11 @@ function! s:SlimeSendOp(type, ...) abort
   let rt = getregtype('"')
 
   if a:0  " Invoked from Visual mode, use '< and '> marks.
-    silent exe "normal! `<" . a:type . '`>y'
+    if g:slime_preserve_curpos_sel == 1
+      silent exe "normal! `<" . a:type . '`>y'
+    else " moves cursor to bottom end of selection when in Visual mode
+      silent exe "normal! `<" . a:type . "`>y']"
+    endif
   elseif a:type == 'line'
     silent exe "normal! '[V']y"
   elseif a:type == 'block'


### PR DESCRIPTION
This option allows users to select several lines of text using visual mode and after sending to vim-slime, preserve their cursor position at the bottom of the selection. 

Keeping the cursor position after Visual mode selection is accessed by unsetting `g:slime_preserve_curpos_sel` 

`let g:slime_preserve_curpos_sel = 0`

Note, unsetting `g:slime_preserve_curpos_sel` changes a default behaviour. When selecting a small portion of text in middle of a long single line of text using Visual mode the cursor will move to the beginning of line, no longer preserving it's cursor location in the middle of line.