### PR TITLE
Make SlimeSend preserve cursor position

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -218,12 +218,12 @@ function! s:SlimeSendOp(type, ...) abort
   call s:SlimeRestoreCurPos()
 endfunction
 
-function! s:SlimeSendRange() range abort
+function! s:SlimeSendRange(startline, endline) abort
   call s:SlimeGetConfig()
 
   let rv = getreg('"')
   let rt = getregtype('"')
-  silent exe a:firstline . ',' . a:lastline . 'yank'
+  silent exe a:startline . ',' . a:endline . 'yank'
   call s:SlimeSend(@")
   call setreg('"', rv, rt)
 endfunction
@@ -290,7 +290,7 @@ endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 command -bar -nargs=0 SlimeConfig call s:SlimeConfig()
-command -range -bar -nargs=0 SlimeSend <line1>,<line2>call s:SlimeSendRange()
+command -range -bar -nargs=0 SlimeSend call s:SlimeSendRange(<line1>, <line2>)
 command -nargs=+ SlimeSend1 call s:SlimeSend(<q-args> . "\r")
 command -nargs=+ SlimeSend0 call s:SlimeSend(<args>)
 command! SlimeSendCurrentLine call s:SlimeSend(getline(".") . "\r")


### PR DESCRIPTION
This resolves #151: SlimeSend doesn't preserve cursor position.