### PR TITLE
Support vim :terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ By default the windows clipboard is used to pass the text to ConEmu. If you
 experience issues with this, make sure the `conemuc` executable is in your
 `path`.
 
+### Vim :terminal
+
+Vim :terminal is *not* the default, to use it you will have to add this line to your .vimrc:
+
+    let g:slime_target = "vimterminal"
+
+When you invoke vim-slime for the first time, you will be prompted for more
+configuration.
+
 Advanced Configuration
 ----------------------
 

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -23,8 +23,9 @@ benefits of using Vim (familiar environment, syntax highlighting, persistence
 3. Tmux Configuration			|slime-tmux|
 4. Neovim Configuration			|slime-neovim|
 5. whimrepl Configuration		|slime-whimrepl|
-6. Slime Configuration			|slime-configuration|
-7. Slime Requirements			|slime-requirements|
+6. vimterminal Configuration		|slime-vimterminal|
+7. Slime Configuration			|slime-configuration|
+8. Slime Requirements			|slime-requirements|
 
 ==============================================================================
 1. Slime Usage 					*slime-usage*
@@ -137,7 +138,23 @@ displays that name in its banner every time you start up an instance of
 whimrepl.
 
 ==============================================================================
-6. Slime Configuration 				*slime-configuration*
+6. Vim :terminal Configuration 			*slime-vimterminal*
+
+Vim :terminal support targets the terminal emulator built into vim from
+version 8.0.0693, accessed via the :terminal command. It does not support the
+neovim implementation of :terminal, which is instead supported by the separate
+'neovim' target.
+
+Vim :terminal is not the default, to use it you will have to add this line to
+your |.vimrc|:
+>
+        let g:slime_target = "vimterminal"
+<
+When you invoke vim-slime for the first time (see below), you will be prompted
+to select from an existing terminal or to create a new one.
+
+==============================================================================
+7. Slime Configuration 				*slime-configuration*
 
 Global Variables~
 						*g:slime_target*
@@ -201,7 +218,7 @@ To use vim like mappings instead of emacs keybindings use the following:
 <
 
 ==============================================================================
-7. Slime Requirements 				*slime-requirements*
+8. Slime Requirements 				*slime-requirements*
 
 Slime requires either screen or tmux to be available and executable. Awk is
 used for completion of screen sessions.  whimrepl does not require any

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -141,6 +141,65 @@ function! s:WhimreplConfig() abort
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" vim terminal
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+function! s:VimterminalSend(config, text)
+  let bufnr = str2nr(get(a:config,"bufnr",""))
+  if len(term_getstatus(bufnr))==0
+    echoerr "Invalid terminal. Use :SlimeConfig to select a terminal"
+    return
+  endif
+  " Ideally we ought to be able to use a single term_sendkeys call however as
+  " of vim 8.0.1203 doing so can cause terminal display issues for longer
+  " selections of text.
+  for l in split(a:text,"\n",1)
+    call term_sendkeys(bufnr,l."\<cr>")
+    call term_wait(bufnr)
+  endfor
+endfunction
+
+function! s:VimterminalDescription(idx,info)
+  let title = term_gettitle(a:info.bufnr)
+  if len(title)==0
+    let title = term_getstatus(a:info.bufnr)
+  endif
+  return printf("%2d.%4d %s [%s]",a:idx,a:info.bufnr,a:info.name,title)
+endfunction
+
+function! s:VimterminalConfig() abort
+  if !exists("*term_start")
+    echoerr "vimterminal support requires vim built with :terminal support"
+    return
+  endif
+  if !exists("b:slime_config")
+    let b:slime_config = {"bufnr": ""}
+  end
+  let bufs = filter(term_list(),"term_getstatus(v:val)=~'running'")
+  let terms = map(bufs,"getbufinfo(v:val)[0]")
+  let choices = map(copy(terms),"s:VimterminalDescription(v:key+1,v:val)")
+  call add(choices, printf("%2d. <New instance>",len(terms)+1))
+  let choice = len(choices)>1
+        \ ? inputlist(choices)
+        \ : 1
+  if choice > 0
+    if choice>len(terms)
+      let cmd = input("Enter a command to run [".&shell."]:")
+      if len(cmd)==0
+        let cmd = &shell
+      endif
+      let winid = win_getid()
+      let new_bufnr = term_start(cmd)
+      call win_gotoid(winid)
+      let b:slime_config["bufnr"] = new_bufnr
+    else
+      let b:slime_config["bufnr"] = terms[choice-1].bufnr
+    endif
+  endif
+endfunction
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Helpers
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 


### PR DESCRIPTION
Hi, I have added a target for the recently implemented vim :terminal command.  It is handled separately from neovim's implementation of :terminal, which is handled by the already existing 'neovim' target.

SlimeConfig allows selection of an existing running :terminal instance, or on-demand creation of a new :terminal instance.