### PR TITLE
Tmux bracketed mode paste enabled

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -60,9 +60,18 @@ function! s:TmuxCommand(config, args)
 endfunction
 
 function! s:TmuxSend(config, text)
-  call s:WritePasteFile(a:text)
+  let l:lastchar = a:text[len(a:text)-1]
+  if l:lastchar == "\n"
+      call s:WritePasteFile(a:text[0:(len(a:text)-2)])
+  elseif
+      call s:WritePasteFile(a:text)
+  endif
   call s:TmuxCommand(a:config, "load-buffer " . g:slime_paste_file)
-  call s:TmuxCommand(a:config, "paste-buffer -d -t " . shellescape(a:config["target_pane"]))
+  call s:TmuxCommand(a:config, "paste-buffer -p -d -t " . shellescape(a:config["target_pane"]))
+  if l:lastchar == "\n"
+      call s:TmuxCommand(a:config, "set-buffer ")
+      call s:TmuxCommand(a:config, "paste-buffer -d -t " . shellescape(a:config["target_pane"]))
+  endif
 endfunction
 
 function! s:TmuxPaneNames(A,L,P)


### PR DESCRIPTION
And the possible ending CR is treated separately given its special meaning for REPL.

It solved the indentation issues for tmux. I checked now no magic is required to paste to python sessions under tmux.

The code is not verified under windows.