### PR TITLE
Fix #161 extra newline with vim8 terminal

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -153,8 +153,8 @@ function! s:VimterminalSend(config, text)
   " Ideally we ought to be able to use a single term_sendkeys call however as
   " of vim 8.0.1203 doing so can cause terminal display issues for longer
   " selections of text.
-  for l in split(a:text,"\n",1)
-    call term_sendkeys(bufnr,l."\<cr>")
+  for l in split(a:text,'\n\zs')
+    call term_sendkeys(bufnr,substitute(l,'\n',"\r",''))
     call term_wait(bufnr)
   endfor
 endfunction


### PR DESCRIPTION
Fix #161 extra newline with vim8 terminal

When sending each line with a carriage return, make sure that the number
of carriage returns is not more than the number of newlines in the text.