### PR TITLE
cleaner support for matlab .m files

### DIFF
--- a/ftplugin/matlab/slime.vim
+++ b/ftplugin/matlab/slime.vim
@@ -1,0 +1,40 @@
+" guess correct number of spaces to indent
+" (tabs cause 'no completion found' messages)
+function! Get_indent_string()
+    return repeat(" ", 4)
+endfunction
+
+" replace tabs by spaces
+function! Tab_to_spaces(text)
+    return substitute(a:text, "	", Get_indent_string(), "g")
+endfunction
+
+
+" Check if line is commented out
+function! Is_comment(line)
+    return (match(a:line, "^[ \t]*%.*") >= 0)
+endfunction
+
+" Remove commented out lines
+function! Remove_line_comments(lines)
+    return filter(copy(a:lines), "!Is_comment(v:val)")
+endfunction
+
+
+" change string into array of lines
+function! Lines(text)
+    return split(a:text, "\n")
+endfunction
+
+" change lines back into text
+function! Unlines(lines)
+    return join(a:lines, "\n") . "\n"
+endfunction
+
+
+" vim slime handler
+function! _EscapeText_matlab(text)
+    let l:lines = Lines(Tab_to_spaces(a:text))
+    let l:lines = Remove_line_comments(l:lines)
+    return Unlines(l:lines)
+endfunction


### PR DESCRIPTION
Hello,

I use vim-slime with MATLAB. When sending text that includes a tab character, the command window spits out "No completions found." This can make reading that window difficult when littered with one of those for every tab that goes by. These changes replace the tab character with 4 spaces and stops this behaviour. It also removes comment lines which are not needed.

The code actually all came from the haskell ftplugin file with only minimal changes needed to get it to work.

Maybe this might be useful if anybody else uses vim-slime and MATLAB!