### PR TITLE
Add Haskell preprocessing options.

### DIFF
--- a/ftplugin/haskell/README.md
+++ b/ftplugin/haskell/README.md
@@ -1,30 +1,41 @@
 
 ### Haskell
 
-This plugin has support for sending haskell source code to the `ghci`. Syntax differences between `ghci`
-are automatically detected and fixed and comments (which aren't allowed in `ghci`) are filtered. Try
-sending the following (correct haskell source code) snippet to `ghci`:
+This plugin has support for sending Haskell source code to `ghci`.
 
+#### Sending normal code
+
+To support older GHC versions, code is processed in order to comply with the
+syntax rules that are specific to interactive mode. For instance when sending
+the following snippet to `ghci`:
+
+    -- make in triplicate
     f :: a -> [a]
     f = replicate 3
 
-This translates to the follwing on the `ghci`:
+This translates to the following:
 
     :{
     let f :: a -> [a]
         f = replicate 3
     :}
 
-because `ghci` expects a `let` in front of a function definition, needs correct indentation and chains multiple lines together
-when they are wrapped in a `:{` `:}` block.
+Some of this behavior can be selectively turned off so that what is run is more
+faithful to the actual code in your buffer, but requires a recent enough GHC:
 
-All of this is very nice but my workflow sometimes requires that I send the same code to the `ghci` over
-and over, so I usually put it in a separate "script" file that holds some testing instructions
-so I can send them quickly.
+* `let g:slime_haskell_ghci_add_let = 0` disables the transformation of
+  top-level bindings into a let binding; requires GHC 8.0.1 or later
 
-However since some of the syntax is different between the `ghci` and normal haskell
-and I write these script files as if I were writing in `ghci`, sometimes the syntax translation would get in 
-the way. Eg. I would write a function call to test a certain function and check it's type:
+#### Sending GHCi scripts
+
+All of this is very nice but my workflow sometimes requires that I send the same
+code to `ghci` over and over, so I usually put it in a separate "script" file
+that holds some testing instructions so I can send them quickly.
+
+However since some of the syntax is different between interactive and normal
+Haskell and I write these script files as if I were writing in `ghci`, sometimes
+the syntax translation would get in the way. E.g. I would write a function call
+to test a certain function and check it's type:
 
     (++) "This is a: " "TEST"
     :type (++)
@@ -38,9 +49,10 @@ and it get translated to:
 
 which is not what I wanted obviously.
 
-To get around this, there is another handler that only kicks in if the filetype in vim is set to `haskell.script`.
-If you want access to this handler call `set ft=haskell.script` or create a new ftdetect file which does this for you
-for a certain file extension. For instance, I have:
+To get around this, there is another handler that only kicks in if the filetype
+in vim is set to `haskell.script`. If you want access to this handler call `set
+ft=haskell.script` or create a new ftdetect file which does this for you for a
+certain file extension. For instance, I have:
 
     au BufRead,BufNewFile,BufNew *.hss setl ft=haskell.script
 

--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -1,3 +1,8 @@
+" GHC before 8.0.1 does not support top-level bindings
+if !exists('g:slime_haskell_ghci_add_let')
+    let g:slime_haskell_ghci_add_let = 1
+endif
+
 " Remove '>' on line beginning in literate haskell
 function! Remove_initial_gt(lines)
     return map(copy(a:lines), "substitute(v:val, '^>[ \t]*', '', 'g')")
@@ -112,8 +117,12 @@ function! _EscapeText_lhaskell(text)
     let l:lines = Remove_initial_gt(l:lines)
     let [l:imports, l:nonImports] = FilterImportLines(l:lines)
     let l:lines = Remove_line_comments(l:nonImports)
-    let l:lines = Perhaps_prepend_let(l:lines)
-    let l:lines = Indent_lines(l:lines)
+
+    if g:slime_haskell_ghci_add_let
+        let l:lines = Perhaps_prepend_let(l:lines)
+        let l:lines = Indent_lines(l:lines)
+    endif
+
     let l:lines = Wrap_if_multi(l:lines)
     return Unlines(l:imports + l:lines)
 endfunction
@@ -123,8 +132,12 @@ function! _EscapeText_haskell(text)
     let l:lines = Lines(Tab_to_spaces(l:text))
     let [l:imports, l:nonImports] = FilterImportLines(l:lines)
     let l:lines = Remove_line_comments(l:nonImports)
-    let l:lines = Perhaps_prepend_let(l:lines)
-    let l:lines = Indent_lines(l:lines)
+
+    if g:slime_haskell_ghci_add_let
+        let l:lines = Perhaps_prepend_let(l:lines)
+        let l:lines = Indent_lines(l:lines)
+    endif
+
     let l:lines = Wrap_if_multi(l:lines)
     return Unlines(l:imports + l:lines)
 endfunction


### PR DESCRIPTION
As suggested in #166, add one option to control the preprocessing of Haskell top-level bindings into a let binding group. This preprocessing is on by default, i.e. this doesn't change from the current behaviour.

I tend to have some reservations with such a piecemeal approach. One way or the other the current handling of Haskell is rough around the edges and could benefit from a more comprehensive, less myopic approach. (But of course that would take time, and I have too much on my plate myself right now.)

Tested (*very* casually) with GHC 7.10.3 and 8.4.4.