### PR TITLE
Mention tmux's special tokens for pane indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,17 +126,24 @@ tmux target pane:
 
 Note that all of these ordinals are 0-indexed by default.
 
-    ":"     means current window, current pane (a reasonable default)
-    ":i"    means the ith window, current pane
-    ":i.j"  means the ith window, jth pane
-    "h:i.j" means the tmux session where h is the session identifier
-            (either session name or number), the ith window and the jth pane
-    "%i"    means i refers the pane's unique id
+    ":"       means current window, current pane (a reasonable default)
+    ":i"      means the ith window, current pane
+    ":i.j"    means the ith window, jth pane
+    "h:i.j"   means the tmux session where h is the session identifier
+              (either session name or number), the ith window and the jth pane
+    "%i"      means i refers the pane's unique id
+    "{token}" one of tmux's supported special tokens, like "{right-of}"
 
 You can configure the defaults for these options. If you generally run vim in
 a split tmux window with a REPL in the other pane:
 
     let g:slime_default_config = {"socket_name": split($TMUX, ",")[0], "target_pane": ":.2"}
+
+Or more reliably by employing [a special token][right-of] as pane index:
+
+    let g:slime_default_config = {"socket_name": "default", "target_pane": "{right-of}"}
+
+[right-of]: http://man.openbsd.org/OpenBSD-current/man1/tmux.1#_right-of_
 
 ### whimrepl
 

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -99,6 +99,7 @@ A tmux pane can be targeted with any of the following values:
   - "h:i.j" means the tmux session where h is the session identifier 
     (either session name or number), the ith window and the jth pane
   - "%i" means i refers the pane's unique id
+  - "{token}" one of tmux's supported special tokens, like "{right-of}"
 
 To get a list of all the available pane execute the following:
 >


### PR DESCRIPTION
As per https://github.com/jpalardy/vim-slime/issues/178#issuecomment-444199477.

Notice that I've also slightly updated the original example. I can revert that and rebase. I did it for it to reflect what is in the [advanced section](https://github.com/jpalardy/vim-slime#advanced-configuration), which is simpler what I was using previously, not sure why it's more complex here, for the same effect.