### PR TITLE
Don't pollute global namespace with ftplugin functions

### DIFF
--- a/autoload/slime/common.vim
+++ b/autoload/slime/common.vim
@@ -1,0 +1,20 @@
+" guess correct number of spaces to indent
+" (tabs cause 'no completion found' messages)
+function! slime#common#get_indent_string() abort
+    return repeat(" ", 4)
+endfunction
+
+" replace tabs by spaces
+function! slime#common#tab_to_spaces(text) abort
+    return substitute(a:text, "	", slime#common#get_indent_string(), "g")
+endfunction
+
+" change string into array of lines
+function! slime#common#lines(text) abort
+    return split(a:text, "\n")
+endfunction
+
+" change lines back into text
+function! slime#common#unlines(lines) abort
+    return join(a:lines, "\n") . "\n"
+endfunction

--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -4,11 +4,11 @@ if !exists('g:slime_haskell_ghci_add_let')
 endif
 
 " Remove '>' on line beginning in literate haskell
-function! Remove_initial_gt(lines)
+function! s:Remove_initial_gt(lines)
     return map(copy(a:lines), "substitute(v:val, '^>[ \t]*', '', 'g')")
 endfunction
 
-function! Is_type_declaration(line)
+function! s:Is_type_declaration(line)
   let l:isNewType = a:line =~ "newtype"
   let l:isTypeAlias = a:line =~ "type"
   let l:isData = a:line =~ "data"
@@ -16,13 +16,13 @@ function! Is_type_declaration(line)
 endfunction
 
 " Prepend certain statements with 'let'
-function! Perhaps_prepend_let(lines)
+function! s:Perhaps_prepend_let(lines)
     if len(a:lines) > 0
         let l:lines = a:lines
         let l:line  = l:lines[0]
 
         " Prepend let if the line is an assignment
-        if (l:line =~ "=[^>]" || l:line =~ "::") && !Is_type_declaration(l:line)
+        if (l:line =~ "=[^>]" || l:line =~ "::") && !s:Is_type_declaration(l:line)
             let l:lines[0] = "let " . l:lines[0]
         endif
 
@@ -32,17 +32,11 @@ function! Perhaps_prepend_let(lines)
     endif
 endfunction
 
-" guess correct number of spaces to indent
-" (tabs are not allowed)
-function! Get_indent_string()
-    return repeat(" ", 4)
-endfunction
-
 " indent lines except for first one.
 " lines are indented equally, so indentation is preserved.
-function! Indent_lines(lines)
+function! s:Indent_lines(lines)
     let l:lines = a:lines
-    let l:indent = Get_indent_string()
+    let l:indent = slime#common#get_indent_string()
     let l:i = 1
     let l:len = len(l:lines)
     while l:i < l:len
@@ -52,29 +46,24 @@ function! Indent_lines(lines)
     return l:lines
 endfunction
 
-" replace tabs by spaces
-function! Tab_to_spaces(text)
-    return substitute(a:text, "	", Get_indent_string(), "g")
-endfunction
-
 " Check if line is commented out
-function! Is_comment(line)
+function! s:Is_comment(line)
     return (match(a:line, "^[ \t]*--.*") >= 0)
 endfunction
 
 " Remove commented out lines
-function! Remove_line_comments(lines)
-    return filter(copy(a:lines), "!Is_comment(v:val)")
+function! s:Remove_line_comments(lines)
+    return filter(copy(a:lines), "!s:Is_comment(v:val)")
 endfunction
 
 " remove block comments
-function! Remove_block_comments(text)
+function! s:Remove_block_comments(text)
     return substitute(a:text, "{-.*-}", "", "g")
 endfunction
 
 " remove line comments
 " todo: fix this! it only removes one occurence whilst it should remove all.
-" function! Remove_line_comments(text)
+" function! s:Remove_line_comments(text)
 "     return substitute(a:text, "^[ \t]*--[^\n]*\n", "", "g")
 " endfunction
 
@@ -87,17 +76,7 @@ function! Wrap_if_multi(lines)
     endif
 endfunction
 
-" change string into array of lines
-function! Lines(text)
-    return split(a:text, "\n")
-endfunction
-
-" change lines back into text
-function! Unlines(lines)
-    return join(a:lines, "\n") . "\n"
-endfunction
-
-function! FilterImportLines(lines)
+function! s:FilterImportLines(lines)
     let l:matches = []
     let l:noMatches = []
     for l:line in a:lines
@@ -112,39 +91,39 @@ endfunction
 
 " vim slime handler
 function! _EscapeText_lhaskell(text)
-    let l:text  = Remove_block_comments(a:text)
-    let l:lines = Lines(Tab_to_spaces(l:text))
-    let l:lines = Remove_initial_gt(l:lines)
-    let [l:imports, l:nonImports] = FilterImportLines(l:lines)
-    let l:lines = Remove_line_comments(l:nonImports)
+    let l:text  = s:Remove_block_comments(a:text)
+    let l:lines = slime#common#lines(slime#common#tab_to_spaces(l:text))
+    let l:lines = s:Remove_initial_gt(l:lines)
+    let [l:imports, l:nonImports] = s:FilterImportLines(l:lines)
+    let l:lines = s:Remove_line_comments(l:nonImports)
 
     if g:slime_haskell_ghci_add_let
-        let l:lines = Perhaps_prepend_let(l:lines)
-        let l:lines = Indent_lines(l:lines)
+        let l:lines = s:Perhaps_prepend_let(l:lines)
+        let l:lines = s:Indent_lines(l:lines)
     endif
 
     let l:lines = Wrap_if_multi(l:lines)
-    return Unlines(l:imports + l:lines)
+    return slime#common#unlines(l:imports + l:lines)
 endfunction
 
 function! _EscapeText_haskell(text)
-    let l:text  = Remove_block_comments(a:text)
-    let l:lines = Lines(Tab_to_spaces(l:text))
-    let [l:imports, l:nonImports] = FilterImportLines(l:lines)
-    let l:lines = Remove_line_comments(l:nonImports)
+    let l:text  = s:Remove_block_comments(a:text)
+    let l:lines = slime#common#lines(slime#common#tab_to_spaces(l:text))
+    let [l:imports, l:nonImports] = s:FilterImportLines(l:lines)
+    let l:lines = s:Remove_line_comments(l:nonImports)
 
     if g:slime_haskell_ghci_add_let
-        let l:lines = Perhaps_prepend_let(l:lines)
-        let l:lines = Indent_lines(l:lines)
+        let l:lines = s:Perhaps_prepend_let(l:lines)
+        let l:lines = s:Indent_lines(l:lines)
     endif
 
     let l:lines = Wrap_if_multi(l:lines)
-    return Unlines(l:imports + l:lines)
+    return slime#common#unlines(l:imports + l:lines)
 endfunction
 
 function! _EscapeText_haskell_script(text)
-    let l:text  = Remove_block_comments(a:text)
-    let l:lines = Lines(Tab_to_spaces(l:text))
-    let l:lines = Remove_line_comments(l:lines)
-    return Unlines(l:lines)
+    let l:text  = s:Remove_block_comments(a:text)
+    let l:lines = slime#common#lines(slime#common#tab_to_spaces(l:text))
+    let l:lines = s:Remove_line_comments(l:lines)
+    return slime#common#unlines(l:lines)
 endfunction

--- a/ftplugin/matlab/slime.vim
+++ b/ftplugin/matlab/slime.vim
@@ -1,40 +1,16 @@
-" guess correct number of spaces to indent
-" (tabs cause 'no completion found' messages)
-function! Get_indent_string()
-    return repeat(" ", 4)
-endfunction
-
-" replace tabs by spaces
-function! Tab_to_spaces(text)
-    return substitute(a:text, "	", Get_indent_string(), "g")
-endfunction
-
-
 " Check if line is commented out
-function! Is_comment(line)
+function! s:Is_comment(line)
     return (match(a:line, "^[ \t]*%.*") >= 0)
 endfunction
 
 " Remove commented out lines
-function! Remove_line_comments(lines)
-    return filter(copy(a:lines), "!Is_comment(v:val)")
+function! s:Remove_line_comments(lines)
+    return filter(copy(a:lines), "!s:Is_comment(v:val)")
 endfunction
-
-
-" change string into array of lines
-function! Lines(text)
-    return split(a:text, "\n")
-endfunction
-
-" change lines back into text
-function! Unlines(lines)
-    return join(a:lines, "\n") . "\n"
-endfunction
-
 
 " vim slime handler
 function! _EscapeText_matlab(text)
-    let l:lines = Lines(Tab_to_spaces(a:text))
-    let l:lines = Remove_line_comments(l:lines)
-    return Unlines(l:lines)
+    let l:lines = slime#common#lines(slime#common#tab_to_spaces(a:text))
+    let l:lines = s:Remove_line_comments(l:lines)
+    return slime#common#unlines(l:lines)
 endfunction


### PR DESCRIPTION
As discussed [here](https://github.com/jpalardy/vim-slime/pull/183#issuecomment-453020461).

Many of these functions have names that may collide with others in the global namespace. For example, both the Haskell and the Matlab ftplugins define a function called Is_comment which is global, so if you open a Haskell file then a Matlab one, the second version of the function will clobber the other.

So, make most of the functions script-local. And the ones that are copy-pasted between the Haskell and Matlab plug-ins, move them into a separate autoloaded file so that they can be shared but only loaded on first use.