### PR TITLE
Fix paste issues in IPython. Add g:slime_dispatch_pause global option.

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -25,7 +25,8 @@ function! s:ScreenSend(config, text)
         \ " -X eval \"readreg p " . g:slime_paste_file . "\"")
   call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
         \ " -X paste p")
-  call system('screen -X colon ""')
+  call system('screen -X colon "
+"')
 endfunction
 
 function! s:ScreenSessionNames(A,L,P)
@@ -347,7 +348,7 @@ function! slime#send(text)
   " will flush the rest of the buffer given a special sequence (ctrl-v)
   " so we, possibly, send many strings -- but probably just one
   let pieces = s:_EscapeText(a:text)
-  for piece in pieces
+    if type(piece) == 0   " a number
     if type(piece) == 0
       if piece != 0
         execute 'sleep' piece . 'm'

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -15,10 +15,6 @@ if !exists("g:slime_paste_file")
   let g:slime_paste_file = expand("$HOME/.slime_paste")
 end
 
-if !exists("g:slime_dispatch_pause")
-  let g:slime_dispatch_pause = 100
-end
-
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -352,8 +348,8 @@ function! slime#send(text)
   " so we, possibly, send many strings -- but probably just one
   let pieces = s:_EscapeText(a:text)
   for piece in pieces
-    if piece == v:null
-      execute 'sleep' g:slime_dispatch_pause . 'm'
+    if type(piece) == 0
+      execute 'sleep' piece . 'm'
     else
       call s:SlimeDispatch('Send', b:slime_config, piece)
     end

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -348,8 +348,8 @@ function! slime#send(text)
   " so we, possibly, send many strings -- but probably just one
   let pieces = s:_EscapeText(a:text)
   for piece in pieces
-    if type(piece) == 0
-      if piece != 0
+    if type(piece) == 0  " a number
+      if piece > 0  " sleep accepts only positive count
         execute 'sleep' piece . 'm'
       endif
     else

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -349,7 +349,9 @@ function! slime#send(text)
   let pieces = s:_EscapeText(a:text)
   for piece in pieces
     if type(piece) == 0
-      execute 'sleep' piece . 'm'
+      if piece != 0
+        execute 'sleep' piece . 'm'
+      endif
     else
       call s:SlimeDispatch('Send', b:slime_config, piece)
     end

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -15,6 +15,10 @@ if !exists("g:slime_paste_file")
   let g:slime_paste_file = expand("$HOME/.slime_paste")
 end
 
+if !exists("g:slime_dispatch_pause")
+  let g:slime_dispatch_pause = 100
+end
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -348,7 +352,11 @@ function! slime#send(text)
   " so we, possibly, send many strings -- but probably just one
   let pieces = s:_EscapeText(a:text)
   for piece in pieces
-    call s:SlimeDispatch('Send', b:slime_config, piece)
+    if piece == v:null
+      execute 'sleep' g:slime_dispatch_pause . 'm'
+    else
+      call s:SlimeDispatch('Send', b:slime_config, piece)
+    end
   endfor
 endfunction
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -25,8 +25,7 @@ function! s:ScreenSend(config, text)
         \ " -X eval \"readreg p " . g:slime_paste_file . "\"")
   call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
         \ " -X paste p")
-  call system('screen -X colon "
-"')
+  call system('screen -X colon ""')
 endfunction
 
 function! s:ScreenSessionNames(A,L,P)
@@ -348,7 +347,7 @@ function! slime#send(text)
   " will flush the rest of the buffer given a special sequence (ctrl-v)
   " so we, possibly, send many strings -- but probably just one
   let pieces = s:_EscapeText(a:text)
-    if type(piece) == 0   " a number
+  for piece in pieces
     if type(piece) == 0
       if piece != 0
         execute 'sleep' piece . 'm'

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,7 +1,11 @@
 
+if !exists("g:slime_dispatch_ipython_pause")
+  let g:slime_dispatch_ipython_pause = 100
+end
+
 function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return ["%cpaste -q\n", v:null, a:text, "--\n"]
+    return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,7 +1,7 @@
 
 function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return ["%cpaste -q\n", a:text, "--\n"]
+    return ["%cpaste -q\n", v:null, a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")


### PR DESCRIPTION
**Summary of Changes**
1. slime#send accepts a mixed list of strings and integers as an argument. The strings are sent with SlimeDispatch. The integers trigger a delay. The length of the delay is the value of the integer in ms.
1. IPython paste issues are fixed by pausing for g:slime_dispatch_ipython_pause milliseconds after sending the "cpaste" command.

**Discussion**
1. Where do you think is the correct place to document the new variable (in the README and/or docs)? For now, it is undocumented.
1. The first commit implements the (second) solution discussed in #172. The second commit implements an improved version (I hope...). The change made enables defining a different delay for each need. Let me know what you think.

I am open to criticism, so feel free to comment. I will make changes as needed.