### PR TITLE
Changes tmux syntax to avoid vim parsing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Note that all of these ordinals are 0-indexed by default.
 You can configure the defaults for these options. If you generally run vim in
 a split tmux window with a REPL in the other pane:
 
-    let g:slime_default_config = {"socket_name": split($TMUX, ",")[0], "target_pane": ":.2"}
+    let g:slime_default_config = {"socket_name": get(split($TMUX, ","), 0), "target_pane": ":.2"}
 
 Or more reliably by employing [a special token][right-of] as pane index:
 


### PR DESCRIPTION
With the previous syntax, using an array index, vim would report an error when editing your .vimrc:
```
E684: list index out of range: 0
```
Using the get syntax avoids this parsing confusion, although both work just fine.

Note, too, that this fixes a major headache I was having where vim-slime was working just fine from tmux (version 2.8), but didn't work inside tmate (version 2.2.1).