### PR TITLE
Default sessionname to $STY

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -34,7 +34,8 @@ endfunction
 
 function! s:ScreenConfig() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"sessionname": "", "windowname": "0"}
+    " STY is the 'Alternative socket name' which is set inside GNU Screen
+    let b:slime_config = {"sessionname": "" . $STY, "windowname": "0"}
   end
   let b:slime_config["sessionname"] = input("screen session name: ", b:slime_config["sessionname"], "custom,<SNR>" . s:SID() . "_ScreenSessionNames")
   let b:slime_config["windowname"]  = input("screen window name: ",  b:slime_config["windowname"])


### PR DESCRIPTION
GNU Screen sessionname defaults to the current session inside which Vim is running.  Permits just hitting enter on the default sessionname.