### PR TITLE
Add the cell-sending functionality

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -284,6 +284,8 @@ function! slime#send_op(type, ...) abort
     silent exe "normal! '[V']y"
   elseif a:type == 'block'
     silent exe "normal! `[\<C-V>`]\y"
+  elseif a:type == 'cell'
+    silent exe ":?" . g:cell_delimiter . "?;/" . g:cell_delimiter . "/y"
   else
     silent exe "normal! `[v`]y"
   endif

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -16,6 +16,7 @@ command! SlimeSendCurrentLine call slime#send(getline(".") . "\r")
 noremap <SID>Operator :<c-u>call slime#store_curpos()<cr>:set opfunc=slime#send_op<cr>g@
 
 noremap <unique> <script> <silent> <Plug>SlimeRegionSend :<c-u>call slime#send_op(visualmode(), 1)<cr>
+noremap <unique> <script> <silent> <Plug>SlimeCellSend :<c-u>call slime#send_op('cell')<cr>
 noremap <unique> <script> <silent> <Plug>SlimeLineSend :<c-u>call slime#send_lines(v:count1)<cr>
 noremap <unique> <script> <silent> <Plug>SlimeMotionSend <SID>Operator
 noremap <unique> <script> <silent> <Plug>SlimeParagraphSend <SID>Operatorip
@@ -33,5 +34,10 @@ if !exists("g:slime_no_mappings") || !g:slime_no_mappings
   if !hasmapto('<Plug>SlimeConfig', 'n')
     nmap <c-c>v <Plug>SlimeConfig
   endif
+
+  if !hasmapto('<Plug>SlimeCellSend', 'n')
+    nmap <c-g> <Plug>SlimeCellSend
+  endif
 endif
 
+let g:cell_delimiter = '\(##\|#%%|#\s%%\)'


### PR DESCRIPTION
Just a few add to allow to use "Cell" like in Spyder or Pyzo e.g.
A cell can be delimited by `##`, `%%`, or `# %%`, and other delimiters can be setted up with
`let g:cell_delimiter`
You can send the cell to IPython using `<Ctrl-g>`

Inspired by _https://github.com/julienr/vim-cellmode_