### PR TITLE
Improve neovim terminal sliming.

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -102,12 +102,12 @@ function! s:NeovimSend(config, text)
   " iPython %cpaste (input buffering: not all lines sent over)
   " So this s:WritePasteFile can help as a small lock & delay
   call s:WritePasteFile(a:text)
-  call jobsend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
+  call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
 endfunction
 
 function! s:NeovimConfig() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"jobid": "1"}
+    let b:slime_config = {"jobid": "3"}
   end
   let b:slime_config["jobid"] = input("jobid: ", b:slime_config["jobid"])
 endfunction


### PR DESCRIPTION
Use jobid 3 as default.
Use chansend function as jobsend is deprecated.

----

I chose jobid 3 as the default after some experimenting. It seems that it opens the first new terminal as 3. Obviously this is not perfect but it should improve the experience of people using neovim at least a little.