### PR TITLE
Additional newline character to correctly enter cpaste mode

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -4,8 +4,8 @@ if !exists("g:slime_dispatch_ipython_pause")
 end
 
 function! _EscapeText_python(text)
-  if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
+  if exists('g:slime_python_ipython')
+    return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, "\n", a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")


### PR DESCRIPTION
New tact. Keep cpaste mode, but just add a newline so it works properly for IPython 7.2. Note, this is also required for pasting a single line.