### PR TITLE
Use tmux bracketed paste. Fixes #191.

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -74,6 +74,9 @@ endfunction
 function! s:TmuxSend(config, text)
   call s:WritePasteFile(a:text)
   call s:TmuxCommand(a:config, "load-buffer " . g:slime_paste_file)
+  call s:TmuxCommand(a:config, "paste-buffer -p -d -t " . shellescape(a:config["target_pane"]))
+  call system("cat > " . g:slime_paste_file, "\n")
+  call s:TmuxCommand(a:config, "load-buffer " . g:slime_paste_file)
   call s:TmuxCommand(a:config, "paste-buffer -d -t " . shellescape(a:config["target_pane"]))
 endfunction
 


### PR DESCRIPTION
From `man tmux`:

> paste-buffer [-dpr] [-b buffer-name] [-s separator] [-t target-pane]
>               (alias: pasteb)
>         Insert the contents of a paste buffer into the specified pane.  If not specified, paste into the current one.  With -d, also delete the paste buffer.  When output, any linefeed (LF) characters in the paste buffer are re‐
>         placed with a separator, by default carriage return (CR).  A custom separator may be specified using the -s flag.  The -r flag means to do no replacement (equivalent to a separator of LF).  **If -p is specified, paste
>         bracket control codes are inserted around the buffer if the application has requested bracketed paste mode**.
