### PR TITLE
Added SlimeSendCell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ By default, vim-slime will try to restore your cursor position after it runs. If
 
     let g:slime_preserve_curpos = 0
 
+If you want to send blocks of code between two delimiters, emulating the cell-like mode of REPL environments like ipython, matlab, etc., you can set the cell delimiter on the `g:slime_cell_delimiter` variable and use the `<Plug>SlimeSendCell` mapping to send the block of code. For example, if your are using ipython you could use the following:
+
+    let g:slime_cell_delimiter = "#%%"
+    nmap <leader>s <Plug>SlimeSendCell
 
 Language Support
 ----------------

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -346,6 +346,18 @@ function! slime#send_lines(count) abort
   call setreg('"', rv, rt)
 endfunction
 
+function! slime#send_cell(cell_delimiter) abort
+  let line_ini = search(a:cell_delimiter, 'bcnW')
+  let line_end = search(a:cell_delimiter, 'nW')
+  if !line_ini
+      let line_ini = 1
+  endif
+  if !line_end
+      let line_end = line("$")
+  endif
+  call slime#send_range(line_ini, line_end)
+endfunction
+
 function! slime#store_curpos()
   if g:slime_preserve_curpos == 1
     let s:cur = winsaveview()

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -11,7 +11,6 @@ command -bar -nargs=0 SlimeConfig call slime#config()
 command -range -bar -nargs=0 SlimeSend call slime#send_range(<line1>, <line2>)
 command -nargs=+ SlimeSend1 call slime#send(<q-args> . "\r")
 command -nargs=+ SlimeSend0 call slime#send(<args>)
-command! SlimeSendCell call slime#send_cell(g:slime_cell_delimiter)
 command! SlimeSendCurrentLine call slime#send(getline(".") . "\r")
 
 noremap <SID>Operator :<c-u>call slime#store_curpos()<cr>:set opfunc=slime#send_op<cr>g@
@@ -21,6 +20,10 @@ noremap <unique> <script> <silent> <Plug>SlimeLineSend :<c-u>call slime#send_lin
 noremap <unique> <script> <silent> <Plug>SlimeMotionSend <SID>Operator
 noremap <unique> <script> <silent> <Plug>SlimeParagraphSend <SID>Operatorip
 noremap <unique> <script> <silent> <Plug>SlimeConfig :<c-u>SlimeConfig<cr>
+if exists("g:slime_cell_delimiter")
+  noremap <unique> <script> <silent> <Plug>SlimeSendCell :<c-u>slime#send_cell(g:slime_cell_delimiter)<cr>
+endif
+
 
 if !exists("g:slime_no_mappings") || !g:slime_no_mappings
   if !hasmapto('<Plug>SlimeRegionSend', 'x')

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -21,7 +21,7 @@ noremap <unique> <script> <silent> <Plug>SlimeMotionSend <SID>Operator
 noremap <unique> <script> <silent> <Plug>SlimeParagraphSend <SID>Operatorip
 noremap <unique> <script> <silent> <Plug>SlimeConfig :<c-u>SlimeConfig<cr>
 if exists("g:slime_cell_delimiter")
-  noremap <unique> <script> <silent> <Plug>SlimeSendCell :<c-u>slime#send_cell(g:slime_cell_delimiter)<cr>
+  noremap <unique> <script> <silent> <Plug>SlimeSendCell :<c-u>call slime#send_cell(g:slime_cell_delimiter)<cr>
 endif
 
 

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -11,6 +11,7 @@ command -bar -nargs=0 SlimeConfig call slime#config()
 command -range -bar -nargs=0 SlimeSend call slime#send_range(<line1>, <line2>)
 command -nargs=+ SlimeSend1 call slime#send(<q-args> . "\r")
 command -nargs=+ SlimeSend0 call slime#send(<args>)
+command! SlimeSendCell call slime#send_cell(g:slime_cell_delimiter)
 command! SlimeSendCurrentLine call slime#send(getline(".") . "\r")
 
 noremap <SID>Operator :<c-u>call slime#store_curpos()<cr>:set opfunc=slime#send_op<cr>g@


### PR DESCRIPTION
New functionality to send blocks of code between two comment strings
(user specified).  This new features tries to emulate the cell-like mode of
popular notebook-type frontends (jupyter, ipython, etc.)

This commit adds the command SlimeSendCell and the function send_cell
which send code between the strings (usually a comment string) specified
in the global variable (by default unset) g:slime_cell_delimiter. 

The new functions/command are written in the same philosophy as the 
vim-slime plugin.

Things that can be improved/added:
* Possibly add a default cell delimiter for each file type (in ftplugin)
* Add this command and possible one example to the documentation