### PR TITLE
Allow override of *Config and *Send function with user-defined functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,29 @@ Context for [SLIME](https://en.wikipedia.org/wiki/SLIME):
 
 Grab some text and send it to a [GNU Screen](http://www.gnu.org/software/screen/) / [tmux](https://tmux.github.io/) / [whimrepl](https://github.com/malyn/lein-whimrepl) / [ConEmu](http://conemu.github.io/) session / NeoVim Terminal / Vim Terminal
 
-    VIM ---(text)---> screen / tmux / whimrepl / ConEmu / NeoVim Terminal / Vim Terminal
+Grab some text and send it to a target, most probably [GNU Screen](http://www.gnu.org/software/screen/), [tmux](https://tmux.github.io/) or [Vim Terminal](https://vimhelp.org/terminal.txt.html).
 
-Presumably, your session contains a [REPL](http://en.wikipedia.org/wiki/REPL), maybe Clojure, R or python. If you can type text into it, vim-slime can send text to it.
+/ [whimrepl](https://github.com/malyn/lein-whimrepl) / [ConEmu](http://conemu.github.io/) session / NeoVim Terminal / Vim Terminal
 
-The reason you're doing this? Because you want the benefits of a REPL and the benefits of using Vim (familiar environment, syntax highlighting, persistence ...).
+    VIM ---(text)---> target {screen / tmux / vim terminal ...}
+
+Presumably, your target contains a [REPL](http://en.wikipedia.org/wiki/REPL), maybe Clojure, R or python. If you can type text into it, vim-slime can send text to it.
+
+The reason for doing this? Because you want the benefits of a REPL and the benefits of using Vim (familiar environment, syntax highlighting, persistence ...).
 
 More details in the [blog post](http://technotales.wordpress.com/2007/10/03/like-slime-for-vim/).
+
+Many targets are supported:
+
+- [GNU Screen](#gnu-screen)
+- [tmux](#tmux)
+- [dtach](#dtach)
+- [kitty](#kitty)
+- [x11](#x11)
+- [whimrepl](#whimrepl)
+- [ConEmu](#conemu)
+- [Vim terminal](#vim-terminal)
+- [NeoVim terminal](#neovim-terminal)
 
 
 Installation
@@ -254,7 +270,7 @@ configuration.
 Advanced Configuration
 ----------------------
 
-If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245) :-)
+If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245) 😄
 
 If you don't want the default key mappings, set:
 
@@ -282,7 +298,7 @@ By default, vim-slime will try to restore your cursor position after it runs. If
 
     let g:slime_preserve_curpos = 0
 
-If you want to send blocks of code between two delimiters, emulating the cell-like mode of REPL environments like ipython, matlab, etc., you can set the cell delimiter on the `g:slime_cell_delimiter` variable and use the `<Plug>SlimeSendCell` mapping to send the block of code. For example, if your are using ipython you could use the following:
+If you want to send blocks of code between two delimiters, emulating the cell-like mode of REPL environments like ipython, matlab, etc., you can set the cell delimiter on the `g:slime_cell_delimiter` variable and use the `<Plug>SlimeSendCell` mapping to send the block of code. For example, if you are using ipython you could use the following:
 
     let g:slime_cell_delimiter = "#%%"
     nmap <leader>s <Plug>SlimeSendCell

--- a/README.md
+++ b/README.md
@@ -19,17 +19,13 @@ Context for [SLIME](https://en.wikipedia.org/wiki/SLIME):
     Vim-slime is a humble attempt at getting _some_ of these features into Vim.
     It works with any REPL and isn't tied to Lisp.
 
-Grab some text and send it to a [GNU Screen](http://www.gnu.org/software/screen/) / [tmux](https://tmux.github.io/) / [whimrepl](https://github.com/malyn/lein-whimrepl) / [ConEmu](http://conemu.github.io/) session / NeoVim Terminal / Vim Terminal
-
-Grab some text and send it to a target, most probably [GNU Screen](http://www.gnu.org/software/screen/), [tmux](https://tmux.github.io/) or [Vim Terminal](https://vimhelp.org/terminal.txt.html).
-
-/ [whimrepl](https://github.com/malyn/lein-whimrepl) / [ConEmu](http://conemu.github.io/) session / NeoVim Terminal / Vim Terminal
+Grab some text and send it to a target, most probably: [GNU Screen](http://www.gnu.org/software/screen/), [tmux](https://tmux.github.io/) or [Vim Terminal](https://vimhelp.org/terminal.txt.html).
 
     VIM ---(text)---> target {screen / tmux / vim terminal ...}
 
 Presumably, your target contains a [REPL](http://en.wikipedia.org/wiki/REPL), maybe Clojure, R or python. If you can type text into it, vim-slime can send text to it.
 
-The reason for doing this? Because you want the benefits of a REPL and the benefits of using Vim (familiar environment, syntax highlighting, persistence ...).
+The reason for doing this? Because you want the benefits of a REPL (instant feedback, no need to reload ...) and the benefits of using Vim (familiar environment, syntax highlighting, persistence ...).
 
 More details in the [blog post](http://technotales.wordpress.com/2007/10/03/like-slime-for-vim/).
 
@@ -39,25 +35,21 @@ Many targets are supported:
 - [tmux](#tmux)
 - [dtach](#dtach)
 - [kitty](#kitty)
-- [x11](#x11)
+- [X11](#x11)
 - [whimrepl](#whimrepl)
 - [ConEmu](#conemu)
-- [Vim terminal](#vim-terminal)
+- [Vim :terminal](#vim-terminal)
 - [NeoVim terminal](#neovim-terminal)
 
 
 Installation
 ------------
 
-I recommend installing [pathogen.vim](https://github.com/tpope/vim-pathogen), and
-then simply copy and paste:
+Use your favorite package manager, or use Vim's built-in package support (since Vim 7.4.1528):
 
-    cd ~/.vim/bundle
-    git clone git://github.com/jpalardy/vim-slime.git
-
-If you like it the hard way, copy autoload, ftplugin and plugin into ~/.vim.
-
-If you would also like to have the documentation available inside Vim, copy doc into ~/.vim as well.
+    mkdir -p ~/.vim/pack/plugins/start
+    cd ~/.vim/pack/plugins/start
+    git clone https://github.com/jpalardy/vim-slime.git
 
 
 Usage
@@ -88,7 +80,7 @@ Configuration
 
 ### GNU Screen
 
-By default, GNU Screen is assumed, you don't have to do anything. If you want
+By default, [GNU Screen](https://www.gnu.org/software/screen/) is assumed, you don't have to do anything. If you want
 to be explicit, you can add this line to your .vimrc:
 
     let g:slime_target = "screen"
@@ -117,13 +109,13 @@ screen window name:
 
 ### tmux
 
-Tmux is *not* the default, to use it you will have to add this line to your .vimrc:
+[Tmux](https://github.com/tmux/tmux) is *not* the default, to use it you will have to add this line to your .vimrc:
 
     let g:slime_target = "tmux"
 
 Before tmux 2.2, tmux accepted input from STDIN. This doesn't work anymore. To
 make it work out without explicit config, the default was changed to use a file
-like screen. By default this file is set to `$HOME/.slime_paste`. The name of
+like Screen. By default this file is set to `$HOME/.slime_paste`. The name of
 the file used can be configured through a variable:
 
     let g:slime_paste_file = "$HOME/.slime_paste"
@@ -150,22 +142,21 @@ Note that all of these ordinals are 0-indexed by default.
     "h:i.j"   means the tmux session where h is the session identifier
               (either session name or number), the ith window and the jth pane
     "%i"      means i refers the pane's unique id
-    "{token}" one of tmux's supported special tokens, like "{right-of}"
+    "{token}" one of tmux's supported special tokens, like "{last}"
 
 You can configure the defaults for these options. If you generally run vim in
 a split tmux window with a REPL in the other pane:
 
     let g:slime_default_config = {"socket_name": get(split($TMUX, ","), 0), "target_pane": ":.2"}
 
-Or more reliably by employing [a special token][right-of] as pane index:
+Or more reliably by employing [a special token](http://man.openbsd.org/OpenBSD-current/man1/tmux.1#_last__2) as pane index:
 
-    let g:slime_default_config = {"socket_name": "default", "target_pane": "{right-of}"}
+    let g:slime_default_config = {"socket_name": "default", "target_pane": "{last}"}
 
-[right-of]: http://man.openbsd.org/OpenBSD-current/man1/tmux.1#_right-of_
 
 ### dtach
 
-dtach is *not* the default, to use it you will have to add this line to your .vimrc:
+[dtach](http://dtach.sourceforge.net/) is *not* the default, to use it you will have to add this line to your .vimrc:
 
     let g:slime_target = "dtach"
 
@@ -178,7 +169,7 @@ socket_path:
 
 ### kitty
 
-kitty is *not* the default, to use it you will have to add this line to your .vimrc:
+[kitty](https://sw.kovidgoyal.net/kitty/) is *not* the default, to use it you will have to add this line to your .vimrc:
 
     let g:slime_target = "kitty"
 
@@ -186,11 +177,12 @@ When you invoke vim-slime for the first time, you will be prompted for more conf
 
 kitty target window
 
-    This is the id of the kitty window that you wish to target. See e.g. the value of $KITTY_WINDOW_ID in the target window.
+    This is the id of the kitty window that you wish to target.
+    See e.g. the value of $KITTY_WINDOW_ID in the target window.
 
 ### X11
 
-x11 is *not* the default, to use it you will have to add this line to your
+[x11](http://manpages.ubuntu.com/manpages/trusty/man1/xdotool.1.html) is *not* the default, to use it you will have to add this line to your
 .vimrc:
 
     let g:slime_target = "x11"
@@ -200,7 +192,7 @@ target window by clicking on it.
 
 ### whimrepl
 
-whimrepl is *not* the default, to use it you will have to add this line to your .vimrc:
+[whimrepl](https://github.com/malyn/lein-whimrepl) is *not* the default, to use it you will have to add this line to your .vimrc:
 
     let g:slime_target = "whimrepl"
 
@@ -214,7 +206,7 @@ whimrepl server name
 
 ### ConEmu
 
-ConEmu is *not* the default, to use it you will have to add this line to your .vimrc:
+[ConEmu](https://conemu.github.io/) is *not* the default, to use it you will have to add this line to your .vimrc:
 
     let g:slime_target = "conemu"
 
@@ -224,7 +216,7 @@ configuration.
 ConEmu console server HWND
 
     This is what you put in the -GuiMacro flag. It will be "0" if you didn't put
-    anything, adressing the active tab/split of the first found ConEmu window.
+    anything, addressing the active tab/split of the first found ConEmu window.
 
 By default the windows clipboard is used to pass the text to ConEmu. If you
 experience issues with this, make sure the `conemuc` executable is in your
@@ -232,7 +224,7 @@ experience issues with this, make sure the `conemuc` executable is in your
 
 ### Vim :terminal
 
-Vim :terminal is *not* the default, to use it you will have to add this line to your .vimrc:
+[Vim :terminal](https://vimhelp.org/terminal.txt.html) is *not* the default, to use it you will have to add this line to your .vimrc:
 
     let g:slime_target = "vimterminal"
 
@@ -260,7 +252,7 @@ for possible options, see :help term_start()
 
 ### NeoVim terminal
 
-NeoVim :terminal is *not* the default, to use it you will have to add this line to your .vimrc:
+[NeoVim :terminal](https://neovim.io/doc/user/nvim_terminal_emulator.html) is *not* the default, to use it you will have to add this line to your .vimrc:
 
     let g:slime_target = "neovim"
 
@@ -270,7 +262,8 @@ configuration.
 Advanced Configuration
 ----------------------
 
-If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245) 😄
+If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245) 😄  
+Seriously, it's not a complicated as it seems.
 
 If you don't want the default key mappings, set:
 
@@ -312,10 +305,12 @@ you want to use.
 Many languages are supported without modifications, while [others](ftplugin)
 might tweak the text without explicit configuration:
 
-  * coffee-script
-  * fsharp
-  * haskell / lhaskell -- [README](ftplugin/haskell)
-  * ocaml
-  * python / ipython -- [README](ftplugin/python)
-  * scala
-  * sml
+  * [coffee-script](ftplugin/coffee/slime.vim)
+  * [fsharp](ftplugin/fsharp/slime.vim)
+  * [haskell](ftplugin/haskell/slime.vim) / [lhaskell](ftplugin/haskell/slime.vim) -- [README](ftplugin/haskell)
+  * [matlab](ftplugin/matlab/slime.vim)
+  * [ocaml](ftplugin/ocaml/slime.vim)
+  * [python](ftplugin/python/slime.vim) / [ipython](ftplugin/python/slime.vim) -- [README](ftplugin/python)
+  * [scala](ftplugin/scala/slime.vim)
+  * [sml](ftplugin/sml/slime.vim)
+  * [stata](ftplugin/stata/slime.vim)

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Contract:
 Write a function named `SlimeOverrideSend`:
 
 ```vim
-functio! SlimeOverrideSend(config, text)
+function SlimeOverrideSend(config, text)
   echom a:config
   call system("send-to-target --key " . a:config["key"], a:text)
 endfunction

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -264,8 +264,8 @@ endfunction
 function! s:_EscapeText(text)
   if exists("&filetype")
     let custom_escape = "_EscapeText_" . substitute(&filetype, "[.]", "_", "g")
-    if exists("*SlimeCustom" . custom_escape)
-      let result = call("SlimeCustom" . custom_escape, [a:text])
+    if exists("*SlimeOverride" . custom_escape)
+      let result = call("SlimeOverride" . custom_escape, [a:text])
     elseif exists("*" . custom_escape)
       let result = call(custom_escape, [a:text])
     end
@@ -404,8 +404,8 @@ endfunction
 " delegation
 function! s:SlimeDispatch(name, ...)
   " allow custom override
-  if exists("*SlimeCustom" . a:name)
-    return call("SlimeCustom" . a:name, a:000)
+  if exists("*SlimeOverride" . a:name)
+    return call("SlimeOverride" . a:name, a:000)
   end
   let target = substitute(tolower(g:slime_target), '\(.\)', '\u\1', '') " Capitalize
   return call("s:" . target . a:name, a:000)

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -401,6 +401,10 @@ endfunction
 
 " delegation
 function! s:SlimeDispatch(name, ...)
+  " allow custom override
+  if exists("*SlimeCustom" . a:name)
+    return call("SlimeCustom" . a:name, a:000)
+  end
   let target = substitute(tolower(g:slime_target), '\(.\)', '\u\1', '') " Capitalize
   return call("s:" . target . a:name, a:000)
 endfunction

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -264,7 +264,9 @@ endfunction
 function! s:_EscapeText(text)
   if exists("&filetype")
     let custom_escape = "_EscapeText_" . substitute(&filetype, "[.]", "_", "g")
-    if exists("*" . custom_escape)
+    if exists("*SlimeCustom" . custom_escape)
+      let result = call("SlimeCustom" . custom_escape, [a:text])
+    elseif exists("*" . custom_escape)
       let result = call(custom_escape, [a:text])
     end
   end


### PR DESCRIPTION
Update: function names changed ⚠️ 

Will be able to override a plugin's default Config and Send (either or both) functions:

```vim
" echo config
" call executable "send-somewhere" by piping text to its STDIN
function! SlimeOverrideSend(config, text)
  echom a:config
  call system("send-somewhere", a:text)
endfunction

" set "key" to (default) 1
function! SlimeOverrideConfig()
  let b:slime_config = {}
  let b:slime_config["key"] = input("key: ", 1)
endfunction

```

More documentation (examples) will be needed to flesh this out.