### PR TITLE
Dont send the delimiters while using the slime#send_cell function

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -357,7 +357,7 @@ function! slime#send_cell(cell_delimiter) abort
   if !line_end
       let line_end = line("$")
   endif
-  call slime#send_range(line_ini, line_end)
+  call slime#send_range(line_ini+1, line_end-1)
 endfunction
 
 function! slime#store_curpos()

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -357,7 +357,9 @@ function! slime#send_cell(cell_delimiter) abort
   " line before delimiter or bottom of file
   let line_end = line_end ? line_end - 1 : line("$")
 
-  call slime#send_range(line_ini, line_end)
+  if line_ini <= line_end
+    call slime#send_range(line_ini, line_end)
+  endif
 endfunction
 
 function! slime#store_curpos()

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -351,13 +351,17 @@ endfunction
 function! slime#send_cell(cell_delimiter) abort
   let line_ini = search(a:cell_delimiter, 'bcnW')
   let line_end = search(a:cell_delimiter, 'nW')
+  let line_ini_delta = 1
+  let line_end_delta = 1
   if !line_ini
       let line_ini = 1
+      let line_ini_delta = 0
   endif
   if !line_end
       let line_end = line("$")
+      let line_end_delta = 0
   endif
-  call slime#send_range(line_ini+1, line_end-1)
+  call slime#send_range(line_ini+line_ini_delta, line_end-line_end_delta)
 endfunction
 
 function! slime#store_curpos()

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -351,17 +351,13 @@ endfunction
 function! slime#send_cell(cell_delimiter) abort
   let line_ini = search(a:cell_delimiter, 'bcnW')
   let line_end = search(a:cell_delimiter, 'nW')
-  let line_ini_delta = 1
-  let line_end_delta = 1
-  if !line_ini
-      let line_ini = 1
-      let line_ini_delta = 0
-  endif
-  if !line_end
-      let line_end = line("$")
-      let line_end_delta = 0
-  endif
-  call slime#send_range(line_ini+line_ini_delta, line_end-line_end_delta)
+
+  " line after delimiter or top of file
+  let line_ini = line_ini ? line_ini + 1 : 1
+  " line before delimiter or bottom of file
+  let line_end = line_end ? line_end - 1 : line("$")
+
+  call slime#send_range(line_ini, line_end)
 endfunction
 
 function! slime#store_curpos()


### PR DESCRIPTION
This small commit allows to send the current block without the delimiters with the send_cell fuction.

I think it make sense to remove the delimiters, since we usually use comments. The log in the target is cleaner this way.

What do you think?