### PR TITLE
Terminate ipython %cpaste

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -5,7 +5,7 @@ end
 
 function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
+    return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text .. "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")


### PR DESCRIPTION
This commit adds submission of "--\n" to terminate the ipython %cpaste command
so the code gets executed by the interpreter.