### PR TITLE
Send separator when using the send_range function

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -15,6 +15,10 @@ if !exists("g:slime_paste_file")
   let g:slime_paste_file = expand("$HOME/.slime_paste")
 end
 
+" separator send before sending a range
+if !exists("g:slime_sendrange_separator")
+  let g:slime_sendrange_separator = ""
+end
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -334,6 +338,10 @@ function! slime#send_range(startline, endline) abort
   let rv = getreg('"')
   let rt = getregtype('"')
   silent exe a:startline . ',' . a:endline . 'yank'
+  if g:slime_sendrange_separator != ""
+    call slime#send(g:slime_sendrange_separator)
+    call slime#send("")
+  endif
   call slime#send(@")
   call setreg('"', rv, rt)
 endfunction


### PR DESCRIPTION
This PR allows to configure a variable (slime_sendrange_separator) in the vimrc to be send before the content of the range.

This allows to see easily the current chunk send to REPL.

Example:

![image](https://user-images.githubusercontent.com/9901302/81006064-2f93d700-8e4f-11ea-9768-aac1855557c8.png)
