### PR TITLE
Add support for Jupyter QTConsole

### DIFF
--- a/ftplugin/python/README.md
+++ b/ftplugin/python/README.md
@@ -9,9 +9,18 @@ interpreter.
 [IPython](http://ipython.org/) has a `%cpaste` "magic function" that allows for
 error-free pasting. In order for vim-slime to make use of this feature for
 Python buffers, you need to set the corresponding variable in your .vimrc:
-
+```
     let g:slime_python_ipython = 1
-
+```
 Note: if you're using IPython 5, you _need_ to set `g:slime_python_ipython` for
-pasting to work correctly.
+pasting to work correctly. [Jupyter Console](https://jupyter-console.readthedocs.io/en/latest/)
+lacks %paste or %cpaste, so IPython should be used instead
+(see [jupyter/jupyter-console#20](https://github.com/jupyter/jupyter_console/issues/20)).
 
+[Jupyter QTConsole](https://qtconsole.readthedocs.io/en/stable/) has a quirk
+where newline characters are not read when pasting. In order for vim-silme to
+send carriage returns instead of newlines for QTConsole, set the following
+variable in your .vimrc:
+```
+    let g:slime_python_qtconsole = 1
+```

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -14,10 +14,10 @@ function! _EscapeText_python(text)
     let except_pat = '\(elif\|else\|except\|finally\)\@!'
     let add_eol_pat = '\n\s[^\n]\+\n\zs\ze\('.except_pat.'\S\|$\)'
     let eol_lines = substitute(dedented_lines, add_eol_pat, "\n", "g")
-    if exists('g:slime_python_ipython_qtconsole')
-        return substitute(eol_lines, '\n', '\r', "g")
-    else
-        return eol_lines
+    if exists('g:slime_python_qtconsole') && g:slime_target == "x11"
+        return [substitute(eol_lines, '\n', "\r", "g"), "\r"]
+    end
+    return eol_lines
   end
 endfunction
 

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -13,7 +13,11 @@ function! _EscapeText_python(text)
     let dedented_lines = substitute(no_empty_lines, dedent_pat, "", "g")
     let except_pat = '\(elif\|else\|except\|finally\)\@!'
     let add_eol_pat = '\n\s[^\n]\+\n\zs\ze\('.except_pat.'\S\|$\)'
-    return substitute(dedented_lines, add_eol_pat, "\n", "g")
+    let eol_lines = substitute(dedented_lines, add_eol_pat, "\n", "g")
+    if exists('g:slime_python_ipython_qtconsole')
+        return substitute(eol_lines, '\n', '\r', "g")
+    else
+        return eol_lines
   end
 endfunction
 


### PR DESCRIPTION
Issue: Newlines were not copied to qtconsole.

Fix: Replace newlines with carriage returns if `g:slime_python_ipython_qtconsole` is set.

Very hasty testing indicates that it works, but it is by no means thorough. This is my first contribution ever, so let me know if there's anything I could improve.