### PR TITLE
More support for iPython & Jupyter console REPLs

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -5,7 +5,15 @@ end
 
 function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return ["\e i", "%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
+    if exists('g:slime_python_vi_repl')
+        return ["\e i","%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
+    else
+        return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
+  if exists('g:slime_python_jupyter') && len(split(a:text,"\n")) > 1
+    if exists('g:slime_python_vi_repl')
+        return ["\e i","%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "\n"]
+    else
+        return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -5,7 +5,7 @@ end
 
 function! _EscapeText_python(text)
   if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
-    return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
+    return ["\e i", "%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")


### PR DESCRIPTION
So there may be a better way of doing this, but I avoided using variables so that the code is as explicit as possible. This PR covers two things: 

* Support for [vi editing mode](https://ipython.readthedocs.io/en/stable/config/options/terminal.html?highlight=vi%20#configtrait-TerminalInteractiveShell.editing_mode) by sending `escape, i` before any text is pasted.
* Trimmed `--` that is appended to each paste for `jupyter console`, whilst still utilising `%cpaste`.

Unfortunately, it does include two extra config options, `g:slime_python_jupyter` and `g:slime_python_vi_repl`. I haven't documented them in the readme, as I wanted to hear your feedback regarding the PR first. 

Cheers!