### PR TITLE
Add Ammonite support to Scala ftplugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ might tweak the text without explicit configuration:
   * [matlab](ftplugin/matlab/slime.vim)
   * [ocaml](ftplugin/ocaml/slime.vim)
   * [python](ftplugin/python/slime.vim) / [ipython](ftplugin/python/slime.vim) -- [README](ftplugin/python)
-  * [scala](ftplugin/scala/slime.vim)
+  * [scala](ftplugin/scala/slime.vim) / [ammonite](ftplugin/scala/slime.vim) -- [README](ftplugin/scala)
   * [sml](ftplugin/sml/slime.vim)
   * [stata](ftplugin/stata/slime.vim)
 

--- a/ftplugin/scala/README.md
+++ b/ftplugin/scala/README.md
@@ -1,0 +1,19 @@
+
+### Scala
+
+By default, vim-slime expects to use the base Scala REPL
+(or [sbt](https://www.scala-sbt.org/) console).
+
+Scala's [Ammonite REPL](https://ammonite.io) is an improved Scala REPL,
+similar to IPython. It does not have a `:paste` command like the default
+REPL, but rather wraps multi-line expressions in curly braces.
+
+To use Ammonite with vim-slime, set the following variable in your .vimrc:
+
+    let g:slime_scala_ammonite = 1
+
+Note that although Scala is usually installed on a per-project basis
+through tools like sbt, setting `let g:slime_scala_ammonite = 1`
+is a global change to your Vim setup.
+You will need to unset the variable in your `.vimrc` before starting Vim
+if you decide not to use Ammonite for a particular project.

--- a/ftplugin/scala/slime.vim
+++ b/ftplugin/scala/slime.vim
@@ -1,5 +1,9 @@
 
 function! _EscapeText_scala(text)
-  return [":paste\n", a:text, ""]
+  if exists('g:slime_scala_ammonite')
+    return ["{\n", a:text, "}\n"]
+  else
+    return [":paste\n", a:text, ""]
+  end
 endfunction
 

--- a/ftplugin/scala/slime.vim
+++ b/ftplugin/scala/slime.vim
@@ -2,8 +2,6 @@
 function! _EscapeText_scala(text)
   if exists('g:slime_scala_ammonite')
     return ["{\n", a:text, "}\n"]
-  else
-    return [":paste\n", a:text, ""]
   end
+  return [":paste\n", a:text, "�"]
 endfunction
-


### PR DESCRIPTION
Addresses #252 

Adds support for Scala's Ammonite REPL if the user sets `let g:slime_scala_ammonite = 1` in their `.vimrc`.

Includes references to the options in the main README, and adds a new README explaining the difference in `ftplugin/scala`.