### PR TITLE
Improve cell delimiter behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ If you want to send blocks of code between two delimiters, emulating the cell-li
     let g:slime_cell_delimiter = "#%%"
     nmap <leader>s <Plug>SlimeSendCell
 
+⚠️  it's recommended to use `b:slime_cell_delimiter` and set the variable in `ftplugin` for each relevant filetype.
+
 
 Advanced Configuration: Overrides
 ---------------------------------

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -15,10 +15,6 @@ if !exists("g:slime_paste_file")
   let g:slime_paste_file = expand("$HOME/.slime_paste")
 end
 
-if !exists("g:slime_cell_delimiter")
-  let g:slime_cell_delimiter = ""
-end
-
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -352,14 +348,18 @@ function! slime#send_lines(count) abort
   call setreg('"', rv, rt)
 endfunction
 
-function! slime#send_cell(cell_delimiter) abort
-  if empty(g:slime_cell_delimiter)
+function! slime#send_cell() abort
+  if exists("b:slime_cell_delimiter")
+    let cell_delimiter = b:slime_cell_delimiter
+  elseif exists("g:slime_cell_delimiter")
+    let cell_delimiter = g:slime_cell_delimiter
+  else
     echoerr "g:slime_cell_delimiter is empty"
     return
   endif
 
-  let line_ini = search(a:cell_delimiter, 'bcnW')
-  let line_end = search(a:cell_delimiter, 'nW')
+  let line_ini = search(cell_delimiter, 'bcnW')
+  let line_end = search(cell_delimiter, 'nW')
 
   " line after delimiter or top of file
   let line_ini = line_ini ? line_ini + 1 : 1

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -15,6 +15,10 @@ if !exists("g:slime_paste_file")
   let g:slime_paste_file = expand("$HOME/.slime_paste")
 end
 
+if !exists("g:slime_cell_delimiter")
+  let g:slime_cell_delimiter = ""
+end
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Screen
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -349,16 +353,20 @@ function! slime#send_lines(count) abort
 endfunction
 
 function! slime#send_cell(cell_delimiter) abort
-  let line_ini = search(a:cell_delimiter, 'bcnW')
-  let line_end = search(a:cell_delimiter, 'nW')
+  if !empty(g:slime_cell_delimiter)
+    let line_ini = search(a:cell_delimiter, 'bcnW')
+    let line_end = search(a:cell_delimiter, 'nW')
 
-  " line after delimiter or top of file
-  let line_ini = line_ini ? line_ini + 1 : 1
-  " line before delimiter or bottom of file
-  let line_end = line_end ? line_end - 1 : line("$")
+    " line after delimiter or top of file
+    let line_ini = line_ini ? line_ini + 1 : 1
+    " line before delimiter or bottom of file
+    let line_end = line_end ? line_end - 1 : line("$")
 
-  if line_ini <= line_end
-    call slime#send_range(line_ini, line_end)
+    if line_ini <= line_end
+      call slime#send_range(line_ini, line_end)
+    endif
+  else
+    echoerr "g:slime_cell_delimiter is empty"
   endif
 endfunction
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -353,20 +353,21 @@ function! slime#send_lines(count) abort
 endfunction
 
 function! slime#send_cell(cell_delimiter) abort
-  if !empty(g:slime_cell_delimiter)
-    let line_ini = search(a:cell_delimiter, 'bcnW')
-    let line_end = search(a:cell_delimiter, 'nW')
-
-    " line after delimiter or top of file
-    let line_ini = line_ini ? line_ini + 1 : 1
-    " line before delimiter or bottom of file
-    let line_end = line_end ? line_end - 1 : line("$")
-
-    if line_ini <= line_end
-      call slime#send_range(line_ini, line_end)
-    endif
-  else
+  if empty(g:slime_cell_delimiter)
     echoerr "g:slime_cell_delimiter is empty"
+    return
+  endif
+
+  let line_ini = search(a:cell_delimiter, 'bcnW')
+  let line_end = search(a:cell_delimiter, 'nW')
+
+  " line after delimiter or top of file
+  let line_ini = line_ini ? line_ini + 1 : 1
+  " line before delimiter or bottom of file
+  let line_end = line_end ? line_end - 1 : line("$")
+
+  if line_ini <= line_end
+    call slime#send_range(line_ini, line_end)
   endif
 endfunction
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -354,7 +354,7 @@ function! slime#send_cell() abort
   elseif exists("g:slime_cell_delimiter")
     let cell_delimiter = g:slime_cell_delimiter
   else
-    echoerr "g:slime_cell_delimiter is empty"
+    echoerr "b:slime_cell_delimeter is not defined"
     return
   endif
 

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -20,8 +20,7 @@ noremap <unique> <script> <silent> <Plug>SlimeLineSend :<c-u>call slime#send_lin
 noremap <unique> <script> <silent> <Plug>SlimeMotionSend <SID>Operator
 noremap <unique> <script> <silent> <Plug>SlimeParagraphSend <SID>Operatorip
 noremap <unique> <script> <silent> <Plug>SlimeConfig :<c-u>SlimeConfig<cr>
-noremap <unique> <script> <silent> <Plug>SlimeSendCell :<c-u>call slime#send_cell(g:slime_cell_delimiter)<cr>
-
+noremap <unique> <script> <silent> <Plug>SlimeSendCell :<c-u>call slime#send_cell()<cr>
 
 if !exists("g:slime_no_mappings") || !g:slime_no_mappings
   if !hasmapto('<Plug>SlimeRegionSend', 'x')

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -20,9 +20,7 @@ noremap <unique> <script> <silent> <Plug>SlimeLineSend :<c-u>call slime#send_lin
 noremap <unique> <script> <silent> <Plug>SlimeMotionSend <SID>Operator
 noremap <unique> <script> <silent> <Plug>SlimeParagraphSend <SID>Operatorip
 noremap <unique> <script> <silent> <Plug>SlimeConfig :<c-u>SlimeConfig<cr>
-if exists("g:slime_cell_delimiter")
-  noremap <unique> <script> <silent> <Plug>SlimeSendCell :<c-u>call slime#send_cell(g:slime_cell_delimiter)<cr>
-endif
+noremap <unique> <script> <silent> <Plug>SlimeSendCell :<c-u>call slime#send_cell(g:slime_cell_delimiter)<cr>
 
 
 if !exists("g:slime_no_mappings") || !g:slime_no_mappings


### PR DESCRIPTION
cc: @mroavi

I started from your PR, but I think I simplified the general flow:

- no need to declare (even empty-default) a `g:slime_cell_delimiter`
- grab first of `b:slime_cell_delimiter` or `g:slime_cell_delimiter`, per ftplugin overrides
- early error if no `slime_cell_delimiter` available

I think all that's missing is some documentation clarification. Thoughts?