### PR TITLE
Fix #251

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,10 @@ All commands to open nvim terminal need the following postfix: <C-\><C-n> :let g
 e.g. A-n to open terminal and get terminal_job_id for slime, then get into insert mode:  
 nnoremap <A-n> :call OpenTerminal() <CR><C-\><C-n> :let g:slime_jobid=b:terminal_job_id <CR>A  
 
-When you invoke vim-slime for the first time, you will be prompted for more
-configuration.
+The first time you need to accept and save the jobid by clicking enter.  
+It is the intended behaviour that opening a 2nd terminal, the old jobid stays and the text is still redirected to the old terminal.  
+To change this :SlimeConfig needs to be called with the new jobid, which is basically unkown,  
+so it is probably a good idea to assign <C-\><C-n> :let g:slime_jobid=b:terminal_job_id <CR>A to a short-cut in init.vim.  
 
 Advanced Configuration
 ----------------------

--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ for possible options, see :help term_start()
 
     let g:slime_target = "neovim"
 
+In ~/.config/nvim/init.vim:  
+All commands to open nvim terminal need the following postfix: <C-\><C-n> :let g:slime_jobid=b:terminal_job_id <CR>A  
+e.g. A-n to open terminal and get terminal_job_id for slime, then get into insert mode:  
+nnoremap <A-n> :call OpenTerminal() <CR><C-\><C-n> :let g:slime_jobid=b:terminal_job_id <CR>A  
+
 When you invoke vim-slime for the first time, you will be prompted for more
 configuration.
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -107,7 +107,7 @@ endfunction
 
 function! s:NeovimConfig() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"jobid": "3"}
+    let b:slime_config = {"jobid": g:slime_jobid}
   end
   let b:slime_config["jobid"] = input("jobid: ", b:slime_config["jobid"])
 endfunction


### PR DESCRIPTION
As in the posts to issue #251 explained, everytime when neovim terminal is called it gets a different job_id, so this one needs to be catched and directed to vim-slime somehow.
I used a global variable for this g:slime_jobid.
Importantly enough to get it automated the postfix:
<C-\><C-n> :let g:slime_jobid=b:terminal_job_id <CR>A
needs to be add to all commands that open the neovim terminal,
so the variable gets automatically assigned when opening a terminal.

The first time you need to accept and save the jobid by clicking enter.
It is the intended behaviour that opening a 2nd terminal, the old jobid stays and the text is still redirected to the old terminal.
To change this :SlimeConfig needs to be called with the new jobid, which is basically unkown,
so it is probably a good idea to assign <C-\><C-n> :let g:slime_jobid=b:terminal_job_id <CR>A to a short-cut in init.vim.

All the needed information for the user is added in the README.md.