### PR TITLE
Strip more comments from stata code lines

### DIFF
--- a/ftplugin/stata/slime.vim
+++ b/ftplugin/stata/slime.vim
@@ -1,4 +1,6 @@
 function! _EscapeText_stata(text)
 	let remove_comments = substitute(a:text, '///\s*\n', " ", "g")
+	let remove_comments = substitute(remove_comments, '//.*\n', "\n", "g")
+	let remove_comments = substitute(remove_comments, '/\*.*\*/', "", "g")
 	return remove_comments
 endfunction


### PR DESCRIPTION
The current stata code only wraps lines that terminate with `///`.

Stata allows for 3 more types of comments:
 * `//` starts a comment anywhere on a line until the new line character
 * `/* */` bookends blocks of code (similar to c++ codeblocks)
 * `*` starts a comment code at the beginning of a line

I add support for the first two other types of code blocks in this pull request. . I don't add code for the third type of code block is not a problem because the Stata REPL treats it as a comment already. Adding it shouldn't be a problem if interested.

I tested with a simple do file and the code seems to be right, but I haven't written Vimscript before so I am not sure if it will work all the time. I will continue to test in the coming days.