### PR TITLE
Use tmux bracketed paste

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -74,7 +74,7 @@ endfunction
 function! s:TmuxSend(config, text)
   call s:WritePasteFile(a:text)
   call s:TmuxCommand(a:config, "load-buffer " . g:slime_paste_file)
-  call s:TmuxCommand(a:config, "paste-buffer -d -t " . shellescape(a:config["target_pane"]))
+  call s:TmuxCommand(a:config, "paste-buffer -p -d -t " . shellescape(a:config["target_pane"]))
 endfunction
 
 function! s:TmuxPaneNames(A,L,P)


### PR DESCRIPTION
Fixes #262, https://github.com/KristofferC/OhMyREPL.jl/issues/224, https://github.com/jpalardy/vim-slime/issues/194#issuecomment-517429613
Related to #254

I tried looking for terminal applications that don't support bracketed paste https://github.com/jpalardy/vim-slime/pull/254#issuecomment-694724480 but haven't managed to find any. Playing around a little bit with it Python hasn't revealed any problems either.