### PR TITLE
Update documentation for slime_paste_file

### DIFF
--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -225,12 +225,11 @@ g:slime_target		Set to either "screen" (default), "tmux" or "whimrepl".
 g:slime_no_mappings	Set to non zero value to disable the default mappings.
 
 						*g:slime_paste_file*
-g:slime_paste_file	Used to transfer data from vim to GNU Screen or tmux.
-			This is required for screen and is set to "$HOME/.slime_paste" by default.
-			For tmux it is optional; If not set, STDIN will be
-			used. Setting this explicitly can work around some
-			occasional portability issues.
-			whimrepl does not require or support this setting.
+g:slime_paste_file	Required to transfer data from vim to GNU screen or
+			tmux. Set to "$HOME/.slime_paste" by default. Setting
+			this explicitly can work around some occasional
+			portability issues. whimrepl does not require or
+			support this setting.
 						*g:slime_preserve_curpos*
 g:slime_preserve_curpos	Set to non zero value to preserve cursor position when
 			sending a line or paragraph. Default is 1.


### PR DESCRIPTION
Using STDIN was deprecated in tmux 2.2