### PR TITLE
Use alternate Kitty text send method supporting Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,25 @@ kitty target window
     This is the id of the kitty window that you wish to target.
     See e.g. the value of $KITTY_WINDOW_ID in the target window.
 
+kitty listen on
+
+    Specifies where kitty should listen to control messages.
+    See e.g. the value of $KITTY_LISTEN_ON in the target window.
+
+To work properly, `kitty` must also be started with the following options:
+
+```sh
+kitty -o allow_remote_control=yes -o enabled_layouts=tall --listen-on unix:/tmp/mykitty
+```
+
+See more [here](https://sw.kovidgoyal.net/kitty/remote-control.html). This can also be added to your `kitty.conf` file as:
+
+```
+allow_remote_control yes
+enabled_layouts tall
+listen_on unix:/tmp/mykitty
+```
+
 ### X11
 
 [x11](http://manpages.ubuntu.com/manpages/trusty/man1/xdotool.1.html) is *not* the default, to use it you will have to add this line to your
@@ -277,7 +296,7 @@ from the buffer running your terminal.
 Advanced Configuration
 ----------------------
 
-If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245) 😄  
+If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245) 😄
 Seriously, it's not a complicated as it seems.
 
 If you don't want the default key mappings, set:

--- a/README.md
+++ b/README.md
@@ -191,14 +191,13 @@ kitty listen on
 To work properly, `kitty` must also be started with the following options:
 
 ```sh
-kitty -o allow_remote_control=yes -o enabled_layouts=tall --listen-on unix:/tmp/mykitty
+kitty -o allow_remote_control=yes --listen-on unix:/tmp/mykitty
 ```
 
 See more [here](https://sw.kovidgoyal.net/kitty/remote-control.html). This can also be added to your `kitty.conf` file as:
 
 ```
 allow_remote_control yes
-enabled_layouts tall
 listen_on unix:/tmp/mykitty
 ```
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ from the buffer running your terminal.
 Advanced Configuration
 ----------------------
 
-If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245) 😄
+If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245) 😄  
 Seriously, it's not a complicated as it seems.
 
 If you don't want the default key mappings, set:

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -56,7 +56,10 @@ function! s:KittyConfig() abort
     let b:slime_config = {"window_id": 1, "listen_on": $KITTY_LISTEN_ON}
   end
   let b:slime_config["window_id"] = input("kitty target window: ", b:slime_config["window_id"])
-  let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
+
+  if has('nvim')
+    let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
+  endif
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -46,15 +46,17 @@ endfunction
 
 function! s:KittySend(config, text)
   call s:WritePasteFile(a:text)
-  call system("kitty @ send-text --match id:" . shellescape(a:config["window_id"]) .
+  call system("kitty @ --to " . shellescape(a:config["listen_on"]) .
+    \ " send-text --match id:" . shellescape(a:config["window_id"]) .
     \ " --from-file " . g:slime_paste_file)
 endfunction
 
 function! s:KittyConfig() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"window_id": 1}
+    let b:slime_config = {"window_id": 1, "listen_on": $KITTY_LISTEN_ON}
   end
   let b:slime_config["window_id"] = input("kitty target window: ", b:slime_config["window_id"])
+  let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
## Summary

Leverages suggestion from https://github.com/jpalardy/vim-slime/issues/234

in response to https://github.com/jpalardy/vim-slime/issues/279

## Testing

Manually confirm slime works when inside a Kitty window (0.18.3) started with documented options, inside regular vim (8.2) and neovim 0.4.4