### PR TITLE
udpate for kitty to select window

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -56,7 +56,7 @@ function! s:KittyConfig() abort
   if !exists("b:slime_config")
     let b:slime_config = {"window_id": 1, "listen_on": ""}
   end
-  let b:slime_config["window_id"] = input("kitty target window: ", b:slime_config["window_id"])
+  let b:slime_config["window_id"] = str2nr(system("kitty @ select-window --self"))
   let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
 endfunction
 


### PR DESCRIPTION
Kitty added a very cool new feature to select window to send command
We don't need to enter manually window ID, which is not evident to find, instead, kitty will pop up numbers for us to choose.
https://github.com/kovidgoyal/kitty/issues/4165#issue-1039321261 
![vim_slime_demo](https://user-images.githubusercontent.com/15676035/140021442-9cd36c9f-63bc-4999-b0bf-f352aaf784df.gif)
