### PR TITLE
Use a temporary file for slime_paste_file

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -12,7 +12,8 @@ end
 
 " screen and tmux need a file, so set a default if not configured
 if !exists("g:slime_paste_file")
-  let g:slime_paste_file = expand("$HOME/.slime_paste")
+  let g:slime_paste_file = tempname()
+  au VimLeave * call delete(g:slime_paste_file)
 end
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
I encountered #49

It occurs that creating a dedicated temporary file seems sound anyway.