### PR TITLE
unset `slime_config` for automatically configuration next time

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -106,6 +106,11 @@ function! s:NeovimSend(config, text)
   " So this s:WritePasteFile can help as a small lock & delay
   call s:WritePasteFile(a:text)
   call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
+  " if b:slime_config is {"jobid": ""} and not configured
+  " then unset it for automatic configuration next time
+  if b:slime_config["jobid"]  == ""
+      unlet b:slime_config
+  endif
 endfunction
 
 function! s:NeovimConfig() abort


### PR DESCRIPTION
If we fail to successfully set the right value for `slime_config` in neovim terminal for the first time, `slime_config`  will be set to some value like  `{"jobid": ""}`.
Then it will not leverage `g:slime_last_channel` to automatically config `slime_config`  next time.

So we unlet `slime_config`  if it fails.