### PR TITLE
small fix for kitty @ select-window till its in main

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -56,8 +56,12 @@ function! s:KittyConfig() abort
   if !exists("b:slime_config")
     let b:slime_config = {"window_id": 1, "listen_on": ""}
   end
-  let b:slime_config["window_id"] = str2nr(system("kitty @ select-window --self"))
   let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
+  let b:slime_config["window_id"] = str2nr(system("kitty @ select-window --self"))
+  if v:shell_error
+    echom 'kitty @select-window failed setting id to 1'
+    let b:slime_config["window_id"] = input("kitty window_id: ","1") 
+  end
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
made a small if `kitty @ select-window` fails prompting the user for window_id , with default 1