### PR TITLE
Prevents slime from interpreting url's as comments in stata

### DIFF
--- a/ftplugin/stata/slime.vim
+++ b/ftplugin/stata/slime.vim
@@ -1,7 +1,7 @@
 
 function! _EscapeText_stata(text)
   let remove_comments = substitute(a:text, '///\s*\n', " ", "g")
-  let remove_comments = substitute(remove_comments, '//.*\n', "\n", "g")
+  let remove_comments = substitute(remove_comments, '\%(https:\)\@<!//.*\n', "\n", "g")
   let remove_comments = substitute(remove_comments, '/\*.*\*/', "", "g")
   return remove_comments
 endfunction


### PR DESCRIPTION
I made a small fix to allow urls to be sent when working with stata. 

Currently, the double forward slashes in a url get interpreted as a comment and everything after them is stripped before being sent.

e.g.
```
use https://stats.idre.ucla.edu/stat/stata/faq/hsb2
```
would be stripped to 
```
use https:
```

Everything is the same except the double forward slash ```//``` is no longer interpreted as a comment if it's preceded by ```https:```