### PR TITLE
A trade-off for #265, allowing to have bracketed-paste in tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,25 +148,25 @@ Note that all of these ordinals are 0-indexed by default.
     "{token}" one of tmux's supported special tokens, like "{last}"
 
 
+You can configure the defaults for these options. If you generally run vim in
+a split tmux window with a REPL in the other pane:
+
+    let g:slime_default_config = {"socket_name": get(split($TMUX, ","), 0), "target_pane": ":.2"}
+
+Or more reliably by employing [a special token](http://man.openbsd.org/OpenBSD-current/man1/tmux.1#_last__2) as pane index:
+
+    let g:slime_default_config = {"socket_name": "default", "target_pane": "{last}"}
+
 tmux bracketed-paste
 
 Sometimes REPL are too smart for their own good, e.g. autocompleting a bracket
 that should not be autocompleted when pasting code from a file. In this case
 it can be useful to rely on bracketed-paste
 (https://cirw.in/blog/bracketed-paste). Luckily, tmux knows how to handle
-that. See tmux's manual. the `bracketed_paste` boolean in the configuration
+that. See tmux's manual. Setting `g:slime_bracketed_paste` to `1` in your `.vimrc`
 enables or disables bracketed-paste. It is disabled by default because it can
 create issues with ipython. See
 [#265](https://github.com/jpalardy/vim-slime/pull/265).
-
-You can configure the defaults for these options. If you generally run vim in
-a split tmux window with a REPL in the other pane:
-
-    let g:slime_default_config = {"socket_name": get(split($TMUX, ","), 0), "target_pane": ":.2", "bracketed_paste":1}
-
-Or more reliably by employing [a special token](http://man.openbsd.org/OpenBSD-current/man1/tmux.1#_last__2) as pane index:
-
-    let g:slime_default_config = {"socket_name": "default", "target_pane": "{last}", "bracketed_paste":1}
 
 
 ### dtach

--- a/README.md
+++ b/README.md
@@ -147,14 +147,26 @@ Note that all of these ordinals are 0-indexed by default.
     "%i"      means i refers the pane's unique id
     "{token}" one of tmux's supported special tokens, like "{last}"
 
+
+tmux bracketed-paste
+
+Sometimes REPL are too smart for their own good, e.g. autocompleting a bracket
+that should not be autocompleted when pasting code from a file. In this case
+it can be useful to rely on bracketed-paste
+(https://cirw.in/blog/bracketed-paste). Luckily, tmux knows how to handle
+that. See tmux's manual. the `bracketed_paste` boolean in the configuration
+enables or disables bracketed-paste. It is disabled by default because it can
+create issues with ipython. See
+[#265](https://github.com/jpalardy/vim-slime/pull/265).
+
 You can configure the defaults for these options. If you generally run vim in
 a split tmux window with a REPL in the other pane:
 
-    let g:slime_default_config = {"socket_name": get(split($TMUX, ","), 0), "target_pane": ":.2"}
+    let g:slime_default_config = {"socket_name": get(split($TMUX, ","), 0), "target_pane": ":.2", "bracketed_paste":1}
 
 Or more reliably by employing [a special token](http://man.openbsd.org/OpenBSD-current/man1/tmux.1#_last__2) as pane index:
 
-    let g:slime_default_config = {"socket_name": "default", "target_pane": "{last}"}
+    let g:slime_default_config = {"socket_name": "default", "target_pane": "{last}", "bracketed_paste":1}
 
 
 ### dtach

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -80,7 +80,14 @@ endfunction
 function! s:TmuxSend(config, text)
   call s:WritePasteFile(a:text)
   call s:TmuxCommand(a:config, "load-buffer " . g:slime_paste_file)
-  if b:slime_config["bracketed_paste"]
+  if exists("b:slime_bracketed_paste")
+    let bracketed_paste = b:slime_bracketed_paste
+  elseif exists("g:slime_bracketed_paste")
+    let bracketed_paste = g:slime_bracketed_paste
+  else
+    let bracketed_paste = 0
+  endif
+  if bracketed_paste
     call s:TmuxCommand(a:config, "paste-buffer -d -p -t " . shellescape(a:config["target_pane"]))
   else
     call s:TmuxCommand(a:config, "paste-buffer -d -t " . shellescape(a:config["target_pane"]))
@@ -94,17 +101,12 @@ endfunction
 
 function! s:TmuxConfig() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"socket_name": "default", "target_pane": ":", "bracketed_paste": 0}
+    let b:slime_config = {"socket_name": "default", "target_pane": ":"}
   end
   let b:slime_config["socket_name"] = input("tmux socket name or absolute path: ", b:slime_config["socket_name"])
   let b:slime_config["target_pane"] = input("tmux target pane: ", b:slime_config["target_pane"], "custom,<SNR>" . s:SID() . "_TmuxPaneNames")
   if b:slime_config["target_pane"] =~ '\s\+'
     let b:slime_config["target_pane"] = split(b:slime_config["target_pane"])[0]
-  endif
-  if input("Use bracketed mode for pasting ? (y/N)") == "y"
-      let b:slime_config["bracketed_paste"] = 1
-  else
-      let b:slime_config["bracketed_paste"] = 0
   endif
 endfunction
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -80,7 +80,11 @@ endfunction
 function! s:TmuxSend(config, text)
   call s:WritePasteFile(a:text)
   call s:TmuxCommand(a:config, "load-buffer " . g:slime_paste_file)
-  call s:TmuxCommand(a:config, "paste-buffer -d -t " . shellescape(a:config["target_pane"]))
+  if b:slime_config["bracketed_paste"]
+    call s:TmuxCommand(a:config, "paste-buffer -d -p -t " . shellescape(a:config["target_pane"]))
+  else
+    call s:TmuxCommand(a:config, "paste-buffer -d -t " . shellescape(a:config["target_pane"]))
+  end
 endfunction
 
 function! s:TmuxPaneNames(A,L,P)
@@ -90,12 +94,17 @@ endfunction
 
 function! s:TmuxConfig() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"socket_name": "default", "target_pane": ":"}
+    let b:slime_config = {"socket_name": "default", "target_pane": ":", "bracketed_paste": 0}
   end
   let b:slime_config["socket_name"] = input("tmux socket name or absolute path: ", b:slime_config["socket_name"])
   let b:slime_config["target_pane"] = input("tmux target pane: ", b:slime_config["target_pane"], "custom,<SNR>" . s:SID() . "_TmuxPaneNames")
   if b:slime_config["target_pane"] =~ '\s\+'
     let b:slime_config["target_pane"] = split(b:slime_config["target_pane"])[0]
+  endif
+  if input("Use bracketed mode for pasting ? (y/N)") == "y"
+      let b:slime_config["bracketed_paste"] = 1
+  else
+      let b:slime_config["bracketed_paste"] = 0
   endif
 endfunction
 

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -107,6 +107,7 @@ A tmux pane can be targeted with any of the following values:
 To get a list of all the available pane execute the following:
 >
 	tmux list-panes -a
+<
 
 Use bracketed-paste mode~
 
@@ -116,10 +117,17 @@ it can be useful to rely on bracketed-paste
 (https://cirw.in/blog/bracketed-paste). Luckily, tmux knows how to handle
 that. See tmux's manual.
 
-You can enable bracketed-paste using
+You can enable bracketed-paste using eiter
 >
-    :SlimeConfig
+    g:slime_bracketed_paste
 <
+or
+>
+    b:slime_bracketed_paste
+<
+
+Note that the buffer variable takes precedence over the global's one.
+
 ==============================================================================
 4. dtach Configuration 			*slime-dtach*
 
@@ -254,6 +262,10 @@ g:slime_default_config	Set to dictionary of pre-filled prompt answer. See
 						*g:slime_dont_ask_default*
 g:slime_dont_ask_default	Works with g:slime_default_config. See
 			the README for details: https://github.com/jpalardy/vim-slime
+
+g:slime_bracketed_paste Set to non zero value to enable bracketed paste in
+                        tmux. See |slime-tmux| or the README for details: 
+                        https://github.com/jpalardy/vim-slime 
 
 Mappings~
 

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -107,6 +107,18 @@ A tmux pane can be targeted with any of the following values:
 To get a list of all the available pane execute the following:
 >
 	tmux list-panes -a
+
+Use bracketed-paste mode~
+
+Sometimes REPL are too smart for their own good, e.g. autocompleting a bracket
+that should not be autocompleted when pasting code from a file. In this case
+it can be useful to rely on bracketed-paste
+(https://cirw.in/blog/bracketed-paste). Luckily, tmux knows how to handle
+that. See tmux's manual.
+
+You can enable bracketed-paste using
+>
+    :SlimeConfig
 <
 ==============================================================================
 4. dtach Configuration 			*slime-dtach*


### PR DESCRIPTION
I reused the work in #265 to allow enabling bracketed-paste in tmux if needed (it's useful in some cases for Julia's OhMyREPL.jl at least). 