### PR TITLE
Add basic commands to navigate between cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ If you want to send blocks of code between two delimiters, emulating the cell-li
 
     let g:slime_cell_delimiter = "#%%"
     nmap <leader>s <Plug>SlimeSendCell
+    nmap <leader>sn <Plug>SlimeNextCell
+    nmap <leader>sp <Plug>SlimePrevCell
+    nmap <leader>ss <Plug>SlimeSendAndGoToNext
 
 ⚠️  it's recommended to use `b:slime_cell_delimiter` and set the variable in `ftplugin` for each relevant filetype.
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -370,16 +370,23 @@ function! slime#send_lines(count) abort
   call setreg('"', rv, rt)
 endfunction
 
-function! slime#send_cell() abort
+function! slime#get_delimiter()
   if exists("b:slime_cell_delimiter")
     let cell_delimiter = b:slime_cell_delimiter
   elseif exists("g:slime_cell_delimiter")
     let cell_delimiter = g:slime_cell_delimiter
   else
     echoerr "b:slime_cell_delimeter is not defined"
-    return
+    return ""
   endif
+    return cell_delimiter
+endfunction
 
+function! slime#send_cell() abort
+  let cell_delimiter = slime#get_delimiter()
+  if cell_delimiter == ""
+      return
+  endif
   let line_ini = search(cell_delimiter, 'bcnW')
   let line_end = search(cell_delimiter, 'nW')
 
@@ -391,6 +398,26 @@ function! slime#send_cell() abort
   if line_ini <= line_end
     call slime#send_range(line_ini, line_end)
   endif
+endfunction
+
+function! slime#go_to_next_cell()
+  let cell_delimiter = slime#get_delimiter()
+  if cell_delimiter == ""
+      return
+  endif
+  let line = search(cell_delimiter, 'eW')
+  let line = line ? line : line("$")
+  call cursor(line, 0)
+endfunction
+
+function! slime#go_to_previous_cell()
+  let cell_delimiter = slime#get_delimiter()
+  if cell_delimiter == ""
+      return
+  endif
+  let line = search(cell_delimiter, 'Wbz')
+  let line = line ? line : 1
+  call cursor(line, 0)
 endfunction
 
 function! slime#store_curpos()

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -57,7 +57,21 @@ benefits of using Vim (familiar environment, syntax highlighting, persistence
                         line, to screen, tmux, or whimrepl. A carriage return
                         is automatically appended.
 
+                                                *slime-cell*
+Working wit cells~
 
+If you want to send blocks of code between two delimiters, emulating the
+cell-like mode of REPL environments like ipython, matlab, etc., you can set
+the cell delimiter on the `g:slime_cell_delimiter` variable and use the
+`<Plug>SlimeSendCell` mapping to send the block of code. For example, if you
+are using ipython you could use the following:
+>
+    let g:slime_cell_delimiter = "#%%"
+    nmap <leader>s <Plug>SlimeSendCell
+    nmap <leader>sn <Plug>SlimeNextCell
+    nmap <leader>sp <Plug>SlimePrevCell
+    nmap <leader>ss <Plug>SlimeSendAndGoToNext
+<
 ==============================================================================
 2. Screen Configuration 			*slime-screen*
 
@@ -267,6 +281,9 @@ g:slime_bracketed_paste Set to non zero value to enable bracketed paste in
                         tmux. See |slime-tmux| or the README for details: 
                         https://github.com/jpalardy/vim-slime 
 
+g:slime_cell_delimiter  Define the cell delimiter used in cell-mode. See
+                        |slime-cell|.
+
 Mappings~
 
 Slime's default mappings can be overridden by setting up mappings in your
@@ -286,6 +303,11 @@ The following special plugin mappings are provided by slime:
   Optional mappings:
   <Plug>SlimeLineSend		Send {count} line(s). Use |nmap|.
   <Plug>SlimeMotionSend		Send {motion}. Use |nmap|.
+  <Plug>SlimeSendCell           Send the current cell. See |slime-cell|.
+  <Plug>SlimeNextCell           Move cursor to next cell. See |slime-cell|.
+  <Plug>SlimePrevCell           Move cursor to previous cell. See |slime-cell|.
+  <Plug>SlimeSendAndGoToNext    Send current cell and move cursor to next cell. 
+                                See |slime-cell|.
 
 Disabling a mapping is as simple as creating a mapping that does not exist,
 for example:

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -21,6 +21,9 @@ noremap <unique> <script> <silent> <Plug>SlimeMotionSend <SID>Operator
 noremap <unique> <script> <silent> <Plug>SlimeParagraphSend <SID>Operatorip
 noremap <unique> <script> <silent> <Plug>SlimeConfig :<c-u>SlimeConfig<cr>
 noremap <unique> <script> <silent> <Plug>SlimeSendCell :<c-u>call slime#send_cell()<cr>
+noremap <unique> <script> <silent> <Plug>SlimeNextCell :<c-u>call slime#go_to_next_cell()<cr>
+noremap <unique> <script> <silent> <Plug>SlimePrevCell :<c-u>call slime#go_to_previous_cell()<cr>
+noremap <unique> <script> <silent> <Plug>SlimeSendAndGoToNext :<c-u>call slime#send_cell()<cr>:call slime#go_to_next_cell()<cr>
 
 if !exists("g:slime_no_mappings") || !g:slime_no_mappings
   if !hasmapto('<Plug>SlimeRegionSend', 'x')


### PR DESCRIPTION
This adds three commands to teach slime how to navigate between cells.