### PR TITLE
Add a link to vim-slime-cells' github repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,3 +454,7 @@ might tweak the text without explicit configuration:
   * [sml](ftplugin/sml/slime.vim)
   * [stata](ftplugin/stata/slime.vim)
 
+Advanced cell-features
+----------------------
+
+If you need more advanced cell features, such as syntax highlighting or cell navigation, you might want to have a look at [vim-slime-cells](https://github.com/Klafyvel/vim-slime-cells).


### PR DESCRIPTION
Following your proposal in https://github.com/jpalardy/vim-slime/issues/315#issuecomment-1002204207_ , I added a link towards my plugin. The new plugin does not use vim-slime's cell feature so you can remove it when you feel the time has come. 

Maybe it is interesting to keep it for now, in order not to break other users configuration ?