### PR TITLE
Made comment matching non-greedy

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -57,6 +57,9 @@ function! s:KittyConfig() abort
     let b:slime_config = {"window_id": 1, "listen_on": ""}
   end
   let b:slime_config["window_id"] = str2nr(system("kitty @ select-window --self"))
+  if v:shell_error
+    let b:slime_config["window_id"] = input("kitty window_id: ","1") 
+  end
   let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
 endfunction
 

--- a/ftplugin/stata/slime.vim
+++ b/ftplugin/stata/slime.vim
@@ -1,8 +1,9 @@
 
 function! _EscapeText_stata(text)
-  let remove_comments = substitute(a:text, '///\s*\n', " ", "g")
-  let remove_comments = substitute(remove_comments, '\%(https:\)\@<!//.*\n', "\n", "g")
-  let remove_comments = substitute(remove_comments, '/\*.*\*/', "", "g")
+  let remove_comments = substitute(a:text, '///[^\n]*\n', ' ', 'g')
+  let remove_comments = substitute(remove_comments, '\n//[^\n]*', '', 'g')
+  let remove_comments = substitute(remove_comments, '\s//[^\n]*', '', 'g')
+  let remove_comments = substitute(remove_comments, '/\*.\{-}\*/', '', 'g')
   return remove_comments
 endfunction
 

--- a/ftplugin/stata/slime.vim
+++ b/ftplugin/stata/slime.vim
@@ -1,7 +1,7 @@
 
 function! _EscapeText_stata(text)
   let remove_comments = substitute(a:text, '///\s*\n', " ", "g")
-  let remove_comments = substitute(remove_comments, '//.*\n', "\n", "g")
+  let remove_comments = substitute(remove_comments, '\%(https:\)\@<!//.*\n', "\n", "g")
   let remove_comments = substitute(remove_comments, '/\*.*\*/', "", "g")
   return remove_comments
 endfunction


### PR DESCRIPTION
Made matching of comments non-greedy. Before when sending a block of code, it would match from the first `//` comment to the end of the last line. Also fixed matching so that comments at the end of line must be proceeded by whitespace as specified in stata documentation. This should also be a better fix for the problem in #313 because a true comment must be proceeded by whitespace.