### PR TITLE
Automatically create missing directories and detect errors when writing to `g:slime_paste_file`

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -292,7 +292,10 @@ function! s:SID()
 endfun
 
 function! s:WritePasteFile(text)
-  call mkdir(fnamemodify(g:slime_paste_file, ":p:h"), "p")
+  let paste_dir = fnamemodify(g:slime_paste_file, ":p:h")
+  if !isdirectory(paste_dir)
+    call mkdir(paste_dir, "p")
+  endif
   let output = system("cat > " . g:slime_paste_file, a:text)
   if v:shell_error
     echoerr output


### PR DESCRIPTION
I'm noticing that vim-slime will fail silently if the folders for `g:slime_paste_file` don't already exist, so here's a fix for that. (If you'd rather not have this, an alternative would be to detect the problem and emit a warning. It's just the current silence that's not ideal.)

The last commit also includes my opinionated change of the default `g:slime_paste_file` to `$HOME/.cache/vim-slime/paste`, but feel free to drop that. (EDIT: changed to use `$XDG_CACHE_HOME` with `$HOME/.cache` as fallback.)