### PR TITLE
Implement buffer-local slime_vimterminal_cmd setting

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -231,13 +231,15 @@ function! s:VimterminalConfig() abort
         \ : 1
   if choice > 0
     if choice>len(terms)
-      if !exists("g:slime_vimterminal_cmd")
-          let cmd = input("Enter a command to run [".&shell."]:")
-          if len(cmd)==0
-            let cmd = &shell
-          endif
+      if exists("b:slime_vimterminal_cmd")
+        let cmd = b:slime_vimterminal_cmd
+      elseif exists("g:slime_vimterminal_cmd")
+        let cmd = g:slime_vimterminal_cmd
       else
-          let cmd = g:slime_vimterminal_cmd
+        let cmd = input("Enter a command to run [".&shell."]:")
+        if len(cmd)==0
+          let cmd = &shell
+        endif
       endif
       let winid = win_getid()
       if exists("g:slime_vimterminal_config")

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -226,15 +226,21 @@ Vim terminal configuration can be set by using the following in your .vimrc:
 
     let g:slime_vimterminal_config = {options}
 
-You can specify if you have frequently used commands:
-
-        let g:slime_vimterminal_cmd = "command"
-
-If you use Node, set it as follows:
-
-        let g:slime_vimterminal_cmd = "node"
-
 for possible options, see help term_start()
+
+You can specify if you have frequently used commands:
+>
+	let b:slime_vimterminal_cmd = "command"
+<
+or
+>
+	let g:slime_vimterminal_cmd = "command"
+<
+For example, if you use Python, set the following in your |.vimrc|:
+>
+	autocmd FileType python let b:slime_vimterminal_cmd='python3'
+<
+Note that the buffer variable takes precedence over the global one.
 
 When you invoke vim-slime for the first time (see below), you will be prompted
 to select from an existing terminal or to create a new one.


### PR DESCRIPTION
Allow users to specify the default vimterminal command as a buffer-local variable. This would allow the default command to vary based on file type. For example:

```vim
autocmd FileType lisp let b:slime_vimterminal_cmd='sbcl'
autocmd FileType python let b:slime_vimterminal_cmd='python3'
```