### PR TITLE
use julia's begin end as if using ipython's %cpaste

### DIFF
--- a/ftplugin/julia/slime.vim
+++ b/ftplugin/julia/slime.vim
@@ -1,7 +1,12 @@
 function! _EscapeText_julia(text)
-  if match(a:text, "\n") > -1
-    return ["begin\n", a:text, "end\n"]
-  end
-  return a:text
+	if exists('g:slime_julia') && len(split(a:text,"\n")) > 1 
+		let empty_3_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\{3,}'
+		let no_empty_3_lines = substitute(a:text, empty_3_lines_pat, "\n\n", "g")
+		if no_empty_3_lines[0:2]=="let" || no_empty_3_lines[0:4]=="begin"
+			return no_empty_3_lines
+		else
+			return ["begin\n", no_empty_3_lines, "end\n"]
+		endif
+	endif
+	return a:text
 endfunction
-


### PR DESCRIPTION
1. provide an option g:slime_julia
2. only substitute `\{3,}` repeat empty lines
3. exclude codes already surround by `begin` or `let`

as https://github.com/jpalardy/vim-slime/pull/341#issuecomment-1231107918 mentioned