### PR TITLE
use julia's begin end as if using ipython's %cpaste with modification

### DIFF
--- a/ftplugin/julia/slime.vim
+++ b/ftplugin/julia/slime.vim
@@ -1,7 +1,12 @@
 function! _EscapeText_julia(text)
-  if match(a:text, "\n") > -1
-    return ["begin\n", a:text, "end\n"]
-  end
+  if exists('g:slime_julia') && len(split(a:text,"\n")) > 1 
+    let empty_2_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\{2,}'
+    let no_empty_2_lines = substitute(a:text, empty_2_lines_pat, "\n", "g")
+    if no_empty_2_lines[0:2]=="let" || no_empty_2_lines[0:4]=="begin"
+      return no_empty_2_lines
+    else
+      return ["begin\n", no_empty_2_lines, "end\n"]
+    endif
+  endif
   return a:text
 endfunction
-


### PR DESCRIPTION
1. provide an option `g:slime_julia`
2. delete repeat empty lines
3. exclude codes already surround by `begin` or `let`