### PR TITLE
Add handler for sh

### DIFF
--- a/ftplugin/sh/slime.vim
+++ b/ftplugin/sh/slime.vim
@@ -1,0 +1,5 @@
+" vim slime handler
+function! _EscapeText_sh(text)
+  let l:lines = slime#common#lines(slime#common#tab_to_spaces(a:text))
+  return slime#common#unlines(l:lines)
+endfunction


### PR DESCRIPTION
If tabs are send into a bash, they trigger bash completion and that results in the REPL not really working as expected. So we translate tabs into spaces, which in context of shell is usually safe operation. There might be some edge cases, but it definitely fixes more things then it breaks.