### PR TITLE
move to the end of selected Visual area

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -357,7 +357,7 @@ function! slime#send_op(type, ...) abort
   let rt = getregtype('"')
 
   if a:0  " Invoked from Visual mode, use '< and '> marks.
-    silent exe "normal! `<" . a:type . '`>y'
+    silent exe "normal! `<" . a:type . "`>y" . "`>"
   elseif a:type == 'line'
     silent exe "normal! '[V']y"
   elseif a:type == 'block'


### PR DESCRIPTION
After SlimeRegionSending, the cursor stays at the start of the selected Visual area. Moving the cursor to the end side would be helpful. It will allow us to just continue to select and send lines that come after.