### PR TITLE
Fix creating emtpy directory when not resolving environment variables

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -359,7 +359,7 @@ function! s:SID()
 endfun
 
 function! s:WritePasteFile(text)
-  let paste_dir = fnamemodify(g:slime_paste_file, ":p:h")
+  let paste_dir = fnamemodify(expand(g:slime_paste_file), ":p:h")
   if !isdirectory(paste_dir)
     call mkdir(paste_dir, "p")
   endif


### PR DESCRIPTION
Thanks for your work on vim-slime! This PR resolves creating an empty directory when specifying a paste-file with environment variable and therefore closes #365 

The directory is created in line 364. This only happens when the `g:slime_paste_file` is explicitly specified in the vimrc-file since the default one from vim-slime is resolved in line 15.

A simple `expand()` on line 362 makes vim expand `$HOME` or whatever environment file there is and resolves the issue for me.