### PR TITLE
Fix the behavior of g:slime_python_ipython

### DIFF
--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -4,7 +4,7 @@ if !exists("g:slime_dispatch_ipython_pause")
 end
 
 function! _EscapeText_python(text)
-  if exists('g:slime_python_ipython') && len(split(a:text,"\n")) > 1
+  if exists('g:slime_python_ipython') && g:slime_python_ipython && len(split(a:text,"\n")) > 1
     return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'


### PR DESCRIPTION
The `g:slime_python_ipython` functionality is intended to be deactivated when its value is set to 0. However, an oversight in the _EscapeText_python function currently ignores this value, which results in the feature remaining enabled even when the flag is set to 0. This pull request rectifies this issue by incorporating the necessary check for this value.