### PR TITLE
Add g:slime_x11_lf_to_cr flag

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -348,7 +348,14 @@ endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 function! s:X11Send(config, text)
-  call system("xdotool type --delay 0 --window " . shellescape(b:slime_config["window_id"]) . " -- " . shellescape(a:text))
+  if !exists("g:slime_x11_lf_to_cr") || !g:slime_x11_lf_to_cr
+      call system("xdotool type --delay 0 --window " . shellescape(b:slime_config["window_id"]) . " -- " . shellescape(a:text))
+  else
+      " In the context of X11 applications such as Jupyter QtConsole,
+      " it's necessary to convert new lines into carriage returns to ensure these
+      " applications are able to correctly interpret and handle multi-line breaks.
+      call system("xdotool type --delay 0 --window " . shellescape(b:slime_config["window_id"]) . " -- " . shellescape(substitute(a:text, '\n', '\r', 'g')))
+  end
 endfunction
 
 function! s:X11Config() abort

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -231,6 +231,14 @@ x11 is not the default, to use it you will have to add this line to your
 When you invoke vim-slime for the first time, you will have to designate a
 target window by clicking on it.
 
+In the context of X11 applications such as Jupyter QtConsolex,
+it's necessary to convert new lines into carriage returns to ensure these
+applications are able to correctly interpret and handle multi-line breaks.
+To enable this feature, add this line to your |.vimrc|:
+>
+        let g:slime_x11_lf_to_cr = 1
+<
+
 ==============================================================================
 10. whimrepl Configuration 			*slime-whimrepl*
 
@@ -313,9 +321,14 @@ g:slime_default_config	Set to dictionary of pre-filled prompt answer. See
 g:slime_dont_ask_default	Works with g:slime_default_config. See
 			the README for details: https://github.com/jpalardy/vim-slime
 
+						*g:slime_bracketed_paste*
 g:slime_bracketed_paste Set to non zero value to enable bracketed paste in
                         tmux. See |slime-tmux| or the README for details: 
                         https://github.com/jpalardy/vim-slime 
+
+						*g:slime_x11_lf_to_cr*
+g:slime_x11_lf_to_cr    Set to non zero value to replace new lines with
+                        carriage returns when the target is X11.
 
 Mappings~
 


### PR DESCRIPTION
While using `vim-slime` with Jupyter QtConsole on Windows WSL, I experienced a multi-line issue similar to the one discussed in https://github.com/jpalardy/vim-slime/issues/297. Upon further investigation, it was discovered that these X11 applications do not break the lines on `\n` but rather on `\r`. This pull request introduces a new configuration variable `g:slime_x11_lf_to_cr`, enabling the substitution of `\n` with `\r` specifically when the target is X11.