### PR TITLE
Add relative direction setting for wezterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,15 @@ wezterm pane id
     This is the id of the wezterm pane that you wish to target.
     See e.g. the value of $WEZTERM_PANE in the target pane.
 
+wezterm pane direction
+
+    If you want the id of the pane in a relative direction to the default, see `wezterm cli get-pane-direction --help` for possible values.
+
+You can configure the defaults for these options. If you generally run vim in
+a split wezterm window with a REPL to the right it could look like this:
+
+    let g:slime_default_config = {"pane_direction": "right"}
+
 Advanced Configuration
 ----------------------
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -139,12 +139,8 @@ function! s:WeztermConfig() abort
   if !exists("b:slime_config")
     let b:slime_config = {"pane_id": 1}
   elseif exists("b:slime_config.pane_direction")
-    let tmp = system("wezterm cli get-pane-direction " . shellescape(b:slime_config["pane_direction"]), "\n")
-    if tmp != ""
-      let b:slime_config = {"pane_id": tmp}
-    else
-      let b:slime_config = {"pane_id": 1}
-    endif
+    let pane_id = system("wezterm cli get-pane-direction " . shellescape(b:slime_config["pane_direction"]))
+    let b:slime_config = {"pane_id": pane_id}
   endif
   let b:slime_config["pane_id"] = input("wezterm pane_id: ", b:slime_config["pane_id"])
 endfunction

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -25,7 +25,8 @@ function! s:ScreenSend(config, text)
         \ " -X eval \"readreg p " . g:slime_paste_file . "\"")
   call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
         \ " -X paste p")
-  call system('screen -X colon ""')
+  call system('screen -X colon "
+"')
 endfunction
 
 function! s:ScreenSessionNames(A,L,P)
@@ -139,7 +140,14 @@ endfunction
 function! s:WeztermConfig() abort
   if !exists("b:slime_config")
     let b:slime_config = {"pane_id": 1}
-  end
+  elseif exists("b:slime_config.pane_direction")
+    let tmp = system("wezterm cli get-pane-direction " . shellescape(b:slime_config["pane_direction"]), "\n")
+    if tmp != ""
+      let b:slime_config = {"pane_id": tmp}
+    else
+      let b:slime_config = {"pane_id": 1}
+    endif
+  endif
   let b:slime_config["pane_id"] = input("wezterm pane_id: ", b:slime_config["pane_id"])
 endfunction
 

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -220,6 +220,15 @@ wezterm pane id~
 
 See e.g. the value of $WEZTERM_PANE in the target pane.
 
+wezterm pane direction~
+
+If you want the id of the pane in a relative direction to the default, see "wezterm cli get-pane-direction --help" for possible values.
+
+You can configure the defaults for these options. If you generally run vim to the left of your REPL, you could set the default pane direction to "right".~
+>
+	let g:slime_default_config = {"pane_direction": "right"}
+<
+
 ==============================================================================
 9. X11 Configuration 				*slime-x11*
 


### PR DESCRIPTION
Noticed that wezterm had the `wezterm cli get-pane-direction DIRECTION` option, meaning we can automatically get the pane id of a relative pane.

For now just added the option to set a default direction, since that is how I typically use it (i.e. I usually always have vim to the left and a repl to the right). 
But maybe it would be nice to allow for a relative direction in the prompt also instead of inserting the id in the case of a relative direction in the default setting.

For now I just wanted to push this since I added it locally for me to use.