### PR TITLE
Refactor: Configuration Lookup

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -534,7 +534,7 @@ function! slime#send_cell() abort
   elseif exists("g:slime_cell_delimiter")
     let cell_delimiter = g:slime_cell_delimiter
   else
-    echoerr "b:slime_cell_delimeter is not defined"
+    echoerr "b:slime_cell_delimiter is not defined"
     return
   endif
 

--- a/autoload/slime/config.vim
+++ b/autoload/slime/config.vim
@@ -1,11 +1,24 @@
+
+let g:slime_config_defaults = {}
+let g:slime_config_defaults["target"] = "screen"
+let g:slime_config_defaults["preserve_curpos"] = 1
+let g:slime_config_defaults["paste_file"] = expand("$HOME/.slime_paste")
+let g:slime_config_defaults["bracketed_paste"] = 0
+
+" -------------------------------------------------
+
 " look for `config_name` in unusal places
 " fallback to default_Value
-function! slime#config#resolve(config_name, default_value)
+function! slime#config#resolve(config_name)
   if exists("b:slime_" . a:config_name)
     return get(b:, "slime_" . a:config_name)
   endif
   if exists("g:slime_" . a:config_name)
     return get(g:, "slime_" . a:config_name)
   endif
-  return a:default_value
+  if has_key(g:slime_config_defaults, a:config_name)
+    return get(g:slime_config_defaults, a:config_name)
+  endif
+  echoerr "missing config value for: slime_" . a:config_name
+  return v:null
 endfunction

--- a/autoload/slime/config.vim
+++ b/autoload/slime/config.vim
@@ -2,13 +2,10 @@
 " fallback to default_Value
 function! slime#config#resolve(config_name, default_value)
   if exists("b:slime_" . a:config_name)
-    echom 'using b: value of ' . a:config_name
-    return eval("b:slime_" . a:config_name)
+    return get(b:, "slime_" . a:config_name)
   endif
   if exists("g:slime_" . a:config_name)
-    echom 'using g: value of ' . a:config_name
-    return eval("g:slime_" . a:config_name)
+    return get(g:, "slime_" . a:config_name)
   endif
-  echom 'using default value of ' . a:config_name
   return a:default_value
 endfunction

--- a/autoload/slime/config.vim
+++ b/autoload/slime/config.vim
@@ -1,0 +1,14 @@
+" look for `config_name` in unusal places
+" fallback to default_Value
+function! slime#config#resolve(config_name, default_value)
+  if exists("b:slime_" . a:config_name)
+    echom 'using b: value of ' . a:config_name
+    return eval("b:slime_" . a:config_name)
+  endif
+  if exists("g:slime_" . a:config_name)
+    echom 'using g: value of ' . a:config_name
+    return eval("g:slime_" . a:config_name)
+  endif
+  echom 'using default value of ' . a:config_name
+  return a:default_value
+endfunction

--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -1,9 +1,4 @@
 
-" GHC before 8.0.1 does not support top-level bindings
-if !exists('g:slime_haskell_ghci_add_let')
-  let g:slime_haskell_ghci_add_let = 1
-endif
-
 " Remove '>' on line beginning in literate haskell
 function! s:Remove_initial_gt(lines)
   return map(copy(a:lines), "substitute(v:val, '^>[ \t]*', '', 'g')")
@@ -98,7 +93,7 @@ function! _EscapeText_lhaskell(text)
   let [l:imports, l:nonImports] = s:FilterImportLines(l:lines)
   let l:lines = s:Remove_line_comments(l:nonImports)
 
-  if g:slime_haskell_ghci_add_let
+  if slime#config#resolve("haskell_ghci_add_let", 1)
     let l:lines = s:Perhaps_prepend_let(l:lines)
     let l:lines = s:Indent_lines(l:lines)
   endif
@@ -113,7 +108,7 @@ function! _EscapeText_haskell(text)
   let [l:imports, l:nonImports] = s:FilterImportLines(l:lines)
   let l:lines = s:Remove_line_comments(l:nonImports)
 
-  if g:slime_haskell_ghci_add_let
+  if slime#config#resolve("haskell_ghci_add_let", 1)
     let l:lines = s:Perhaps_prepend_let(l:lines)
     let l:lines = s:Indent_lines(l:lines)
   endif

--- a/ftplugin/haskell/slime.vim
+++ b/ftplugin/haskell/slime.vim
@@ -1,4 +1,7 @@
 
+" GHC before 8.0.1 does not support top-level bindings
+let g:slime_config_defaults["haskell_ghci_add_let"] = 1
+
 " Remove '>' on line beginning in literate haskell
 function! s:Remove_initial_gt(lines)
   return map(copy(a:lines), "substitute(v:val, '^>[ \t]*', '', 'g')")
@@ -93,7 +96,7 @@ function! _EscapeText_lhaskell(text)
   let [l:imports, l:nonImports] = s:FilterImportLines(l:lines)
   let l:lines = s:Remove_line_comments(l:nonImports)
 
-  if slime#config#resolve("haskell_ghci_add_let", 1)
+  if slime#config#resolve("haskell_ghci_add_let")
     let l:lines = s:Perhaps_prepend_let(l:lines)
     let l:lines = s:Indent_lines(l:lines)
   endif
@@ -108,7 +111,7 @@ function! _EscapeText_haskell(text)
   let [l:imports, l:nonImports] = s:FilterImportLines(l:lines)
   let l:lines = s:Remove_line_comments(l:nonImports)
 
-  if slime#config#resolve("haskell_ghci_add_let", 1)
+  if slime#config#resolve("haskell_ghci_add_let")
     let l:lines = s:Perhaps_prepend_let(l:lines)
     let l:lines = s:Indent_lines(l:lines)
   endif

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,7 +1,10 @@
 
+let g:slime_config_defaults["python_ipython"] = 0
+let g:slime_config_defaults["dispatch_ipython_pause"] = 100
+
 function! _EscapeText_python(text)
-  if slime#config#resolve("python_ipython", 0) && len(split(a:text,"\n")) > 1
-    return ["%cpaste -q\n", slime#config#resolve("dispatch_ipython_pause", 100), a:text, "--\n"]
+  if slime#config#resolve("python_ipython") && len(split(a:text,"\n")) > 1
+    return ["%cpaste -q\n", slime#config#resolve("dispatch_ipython_pause"), a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")

--- a/ftplugin/python/slime.vim
+++ b/ftplugin/python/slime.vim
@@ -1,11 +1,7 @@
 
-if !exists("g:slime_dispatch_ipython_pause")
-  let g:slime_dispatch_ipython_pause = 100
-end
-
 function! _EscapeText_python(text)
-  if exists('g:slime_python_ipython') && g:slime_python_ipython && len(split(a:text,"\n")) > 1
-    return ["%cpaste -q\n", g:slime_dispatch_ipython_pause, a:text, "--\n"]
+  if slime#config#resolve("python_ipython", 0) && len(split(a:text,"\n")) > 1
+    return ["%cpaste -q\n", slime#config#resolve("dispatch_ipython_pause", 100), a:text, "--\n"]
   else
     let empty_lines_pat = '\(^\|\n\)\zs\(\s*\n\+\)\+'
     let no_empty_lines = substitute(a:text, empty_lines_pat, "", "g")

--- a/ftplugin/scala/slime.vim
+++ b/ftplugin/scala/slime.vim
@@ -1,6 +1,8 @@
 
+let g:slime_config_defaults["scala_ammonite"] = 0
+
 function! _EscapeText_scala(text)
-  if slime#config#resolve("scala_ammonite", 0)
+  if slime#config#resolve("scala_ammonite")
     return ["{\n", a:text, "}\n"]
   end
   " \x04 is ctrl-d

--- a/ftplugin/scala/slime.vim
+++ b/ftplugin/scala/slime.vim
@@ -1,6 +1,6 @@
 
 function! _EscapeText_scala(text)
-  if exists('g:slime_scala_ammonite')
+  if slime#config#resolve("scala_ammonite", 0)
     return ["{\n", a:text, "}\n"]
   end
   " \x04 is ctrl-d

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -38,7 +38,7 @@ endif
 
 " for neovim (only), make slime_last_channel contain
 " the channel id of the last opened terminal
-if get(g:, "slime_target", "") == "neovim"
+if slime#config#resolve("target", "screen") == "neovim"
   augroup nvim_slime
     autocmd!
     autocmd TermOpen * let g:slime_last_channel = &channel

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -38,7 +38,7 @@ endif
 
 " for neovim (only), make slime_last_channel contain
 " the channel id of the last opened terminal
-if slime#config#resolve("target", "screen") == "neovim"
+if slime#config#resolve("target") == "neovim"
   augroup nvim_slime
     autocmd!
     autocmd TermOpen * let g:slime_last_channel = &channel


### PR DESCRIPTION
Previously, there was a lot of redundant code to perform configuration lookup.

The logic remains the same, but is now explicitly done in `slime#config#resolve` as:
- use `b:` (buffer) config, if it exists
- use `g:` (global) config, if it exists
- fallback to defaults — now contained in `g:slime_config_defaults`
- `echoerr` if no default exists

### Discussion

- logic is centralized
- handling is consistent
  - some values did not have `b:`-level overrides
  - some values were evaluated once (at load time) and cached
- defaults are centralized
- ftplugins can leverage same mechanism for defaults/lookup (see below)