### PR TITLE
Refactor: Unified System Calls

### DIFF
--- a/autoload/slime/common.vim
+++ b/autoload/slime/common.vim
@@ -24,7 +24,7 @@ function! slime#common#write_paste_file(text)
   if !isdirectory(paste_dir)
     call mkdir(paste_dir, "p")
   endif
-  let output = system("cat > " . shellescape(slime#config#resolve("paste_file")), a:text)
+  let output = slime#common#system("cat > %s", [slime#config#resolve("paste_file")], a:text)
   if v:shell_error
     echoerr output
   endif

--- a/autoload/slime/common.vim
+++ b/autoload/slime/common.vim
@@ -34,3 +34,7 @@ function! slime#common#capitalize(text)
   return substitute(tolower(a:text), '\(.\)', '\u\1', '')
 endfunction
 
+function! slime#common#system(cmd_template, args, ...)
+  let escaped_args = map(copy(a:args), "shellescape(v:val)")
+  return call('system', [call('printf', [a:cmd_template] + escaped_args)] + a:000)
+endfunction

--- a/autoload/slime/targets/conemu.vim
+++ b/autoload/slime/targets/conemu.vim
@@ -1,7 +1,6 @@
 
 function! slime#targets#conemu#config() abort
-  " set destination for send commands, as specified in
-  " http://conemu.github.io/en/GuiMacro.html#Command_line
+  " set destination for send commands, as specified in http://conemu.github.io/en/GuiMacro.html#Command_line
   if !exists("b:slime_config")
     " defaults to the active tab/split of the first found ConEmu window
     let b:slime_config = {"HWND": "0"}
@@ -10,13 +9,11 @@ function! slime#targets#conemu#config() abort
 endfunction
 
 function! slime#targets#conemu#send(config, text)
-  let l:prefix = "conemuc -guimacro:" . a:config["HWND"]
-  " use the selection register to send text to ConEmu using the windows
-  " clipboard (see help gui-clipboard)
+  " use the selection register to send text to ConEmu using the windows clipboard (see help gui-clipboard)
   " save the current selection to restore it after send
   let tmp = @*
   let @* = a:text
-  call system(l:prefix . " print")
+  call slime#common#system("conemuc -guimacro:%s print", [a:config["HWND"]])
   let @* = tmp
 endfunction
 

--- a/autoload/slime/targets/dtach.vim
+++ b/autoload/slime/targets/dtach.vim
@@ -7,6 +7,6 @@ function! slime#targets#dtach#config() abort
 endfunction
 
 function! slime#targets#dtach#send(config, text)
-  call system("dtach -p " . shellescape(b:slime_config["socket_path"]), a:text)
+  call slime#common#system("dtach -p %s", [a:config["socket_path"]], a:text)
 endfunction
 

--- a/autoload/slime/targets/kitty.vim
+++ b/autoload/slime/targets/kitty.vim
@@ -3,7 +3,7 @@ function! slime#targets#kitty#config() abort
   if !exists("b:slime_config")
     let b:slime_config = {"window_id": 1, "listen_on": ""}
   end
-  let b:slime_config["window_id"] = str2nr(system("kitty @ select-window --self"))
+  let b:slime_config["window_id"] = str2nr(slime#common#system("kitty @ select-window --self", []))
   if v:shell_error || b:slime_config["window_id"] == $KITTY_WINDOW_ID
     let b:slime_config["window_id"] = input("kitty window_id: ", b:slime_config["window_id"])
   endif
@@ -23,11 +23,16 @@ function! slime#targets#kitty#send(config, text)
     let text_to_paste = "\e[200~" . text_to_paste . "\e[201~"
   endif
 
-  let to_flag = ""
-  if a:config["listen_on"] != ""
-    let to_flag = " --to " . shellescape(a:config["listen_on"])
-  end
+  let target_cmd = s:target_cmd(a:config["listen_on"])
+  call slime#common#system(target_cmd . " send-text --match id:%s --stdin", [a:config["window_id"]], text_to_paste)
+endfunction
 
-  call system("kitty @" . to_flag . " send-text --match id:" . shellescape(a:config["window_id"]) . " --stdin", text_to_paste)
+" -------------------------------------------------
+
+function! s:target_cmd(listen_on)
+  if a:listen_on != ""
+    return "kitty @ --to " . shellescape(a:listen_on)
+  end
+  return "kitty @"
 endfunction
 

--- a/autoload/slime/targets/screen.vim
+++ b/autoload/slime/targets/screen.vim
@@ -9,15 +9,13 @@ endfunction
 
 function! slime#targets#screen#send(config, text)
   call slime#common#write_paste_file(a:text)
-  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
-        \ " -X eval \"readreg p " . slime#config#resolve("paste_file") . "\"")
-  call system("screen -S " . shellescape(a:config["sessionname"]) . " -p " . shellescape(a:config["windowname"]) .
-        \ " -X paste p")
+  call slime#common#system('screen -S %s -p %s -X eval "readreg p %s"', [a:config["sessionname"], a:config["windowname"], slime#config#resolve("paste_file")])
+  call slime#common#system('screen -S %s -p %s -X paste p', [a:config["sessionname"], a:config["windowname"]])
 endfunction
 
 " -------------------------------------------------
 
 function! slime#targets#screen#session_names(A,L,P)
-  return system("screen -ls | awk '/Attached/ {print $1}'")
+  return slime#common#system("screen -ls | awk '/Attached/ {print $1}'", [])
 endfunction
 

--- a/autoload/slime/targets/tmux.vim
+++ b/autoload/slime/targets/tmux.vim
@@ -51,10 +51,8 @@ function! slime#targets#tmux#pane_names(A,L,P)
 endfunction
 
 function! s:TmuxCommand(config, cmd_template, ...)
-  " For an absolute path to the socket, use tmux -S.
-  " For a relative path to the socket in tmux's temporary directory, use tmux -L.
-  " Case sensitivity does not matter here, but let's follow good practice.
-  " TODO: Make this cross-platform. Windows supports tmux as of mid-2016.
+  " socket with absolute path: use tmux -S
+  " socket with relative path: use tmux -L
   if a:config["socket_name"] =~ "^/"
     let tmux_cmd = "tmux -S %s " . a:cmd_template
   else

--- a/autoload/slime/targets/tmux.vim
+++ b/autoload/slime/targets/tmux.vim
@@ -11,6 +11,7 @@ function! slime#targets#tmux#config() abort
 endfunction
 
 function! slime#targets#tmux#send(config, text)
+  let target_cmd = s:target_cmd(a:config["socket_name"])
   let bracketed_paste = slime#config#resolve("bracketed_paste")
 
   let [text_to_paste, has_crlf] = [a:text, 0]
@@ -28,36 +29,34 @@ function! slime#targets#tmux#send(config, text)
   for i in range(0, len(text_to_paste) / chunk_size)
     let chunk = text_to_paste[i * chunk_size : (i + 1) * chunk_size - 1]
     call slime#common#write_paste_file(chunk)
-    call s:TmuxCommand(a:config, "load-buffer %s", slime#config#resolve("paste_file"))
-    call s:TmuxCommand(a:config, "send-keys -X -t %s cancel", a:config["target_pane"])
+    call slime#common#system(target_cmd . " load-buffer %s", [slime#config#resolve("paste_file")])
+    call slime#common#system(target_cmd . " send-keys -X -t %s cancel", [a:config["target_pane"]])
     if bracketed_paste
-      call s:TmuxCommand(a:config, "paste-buffer -d -p -t %s", a:config["target_pane"])
+      call slime#common#system(target_cmd . " paste-buffer -d -p -t %s", [a:config["target_pane"]])
     else
-      call s:TmuxCommand(a:config, "paste-buffer -d -t %s", a:config["target_pane"])
+      call slime#common#system(target_cmd . " paste-buffer -d -t %s", [a:config["target_pane"]])
     end
   endfor
 
   " trailing newline
   if has_crlf
-    call s:TmuxCommand(a:config, "send-keys -t %s Enter", a:config["target_pane"])
+    call slime#common#system(target_cmd . " send-keys -t %s Enter", [a:config["target_pane"]])
   end
 endfunction
 
 " -------------------------------------------------
 
 function! slime#targets#tmux#pane_names(A,L,P)
+  let target_cmd = s:target_cmd(b:slime_config["socket_name"])
   let format = '#{pane_id} #{session_name}:#{window_index}.#{pane_index} #{window_name}#{?window_active, (active),}'
-  return s:TmuxCommand(b:slime_config, "list-panes -a -F %s", format)
+  return slime#common#system(target_cmd . " list-panes -a -F %s", [format])
 endfunction
 
-function! s:TmuxCommand(config, cmd_template, ...)
+function! s:target_cmd(socket_name)
   " socket with absolute path: use tmux -S
-  " socket with relative path: use tmux -L
-  if a:config["socket_name"] =~ "^/"
-    let tmux_cmd = "tmux -S %s " . a:cmd_template
-  else
-    let tmux_cmd = "tmux -L %s " . a:cmd_template
+  if a:socket_name =~ "^/"
+    return "tmux -S " . shellescape(a:socket_name)
   endif
-  return slime#common#system(tmux_cmd, [a:config["socket_name"]] + a:000)
+  " socket with relative path: use tmux -L
+  return "tmux -L " . shellescape(a:socket_name)
 endfunction
-

--- a/autoload/slime/targets/wezterm.vim
+++ b/autoload/slime/targets/wezterm.vim
@@ -3,7 +3,7 @@ function! slime#targets#wezterm#config() abort
   if !exists("b:slime_config")
     let b:slime_config = {"pane_id": 1}
   elseif exists("b:slime_config.pane_direction")
-    let pane_id = system("wezterm cli get-pane-direction " . shellescape(b:slime_config["pane_direction"]))
+    let pane_id = slime#common#system("wezterm cli get-pane-direction %s", [b:slime_config["pane_direction"]])
     let b:slime_config = {"pane_id": pane_id}
   endif
   let b:slime_config["pane_id"] = input("wezterm pane_id: ", b:slime_config["pane_id"])
@@ -22,14 +22,14 @@ function! slime#targets#wezterm#send(config, text)
   endif
 
   if bracketed_paste
-    call system("wezterm cli send-text --pane-id=" . shellescape(a:config["pane_id"]), text_to_paste)
+    call slime#common#system("wezterm cli send-text --pane-id=%s", [a:config["pane_id"]], text_to_paste)
   else
-    call system("wezterm cli send-text --no-paste --pane-id=" . shellescape(a:config["pane_id"]), text_to_paste)
+    call slime#common#system("wezterm cli send-text --no-paste --pane-id=%s", [a:config["pane_id"]], text_to_paste)
   endif
 
   " trailing newline
   if has_crlf
-    call system("wezterm cli send-text --no-paste --pane-id=" . shellescape(a:config["pane_id"]), "\n")
+    call slime#common#system("wezterm cli send-text --no-paste --pane-id=%s", [a:config["pane_id"]], "\n")
   end
 endfunction
 

--- a/autoload/slime/targets/x11.vim
+++ b/autoload/slime/targets/x11.vim
@@ -3,10 +3,10 @@ function! slime#targets#x11#config() abort
   if !exists("b:slime_config")
     let b:slime_config = {"window_id": ""}
   end
-  let b:slime_config["window_id"] = trim(system("xdotool selectwindow"))
+  let b:slime_config["window_id"] = trim(slime#common#system("xdotool selectwindow", []))
 endfunction
 
 function! slime#targets#x11#send(config, text)
-  call system("xdotool type --delay 0 --window " . shellescape(b:slime_config["window_id"]) . " -- " . shellescape(a:text))
+  call slime#common#system("xdotool type --delay 0 --window %s -- %s", [a:config["window_id"], a:text])
 endfunction
 

--- a/autoload/slime/targets/zellij.vim
+++ b/autoload/slime/targets/zellij.vim
@@ -21,12 +21,9 @@ function! slime#targets#zellij#config() abort
 endfunction
 
 function! slime#targets#zellij#send(config, text)
-  let target_session = ""
-  if a:config["session_id"] != "current"
-    let target_session = "-s " . shellescape(a:config["session_id"])
-  end
+  let target_cmd = s:target_cmd(a:config["session_id"])
   if a:config["relative_pane"] != "current"
-    call system("zellij " . target_session . " action move-focus " . shellescape(a:config["relative_pane"]))
+    call slime#common#system(target_cmd . " action move-focus %s",  [a:config["relative_pane"]])
   end
   let bracketed_paste = slime#config#resolve("bracketed_paste")
 
@@ -40,18 +37,27 @@ function! slime#targets#zellij#send(config, text)
   endif
 
   if bracketed_paste
-    call system("zellij " . target_session . " action write 27 91 50 48 48 126")
-    call system("zellij " . target_session . " action write-chars " . shellescape(text_to_paste))
-    call system("zellij " . target_session . " action write 27 91 50 48 49 126")
+    call slime#common#system(target_cmd . " action write 27 91 50 48 48 126", [])
+    call slime#common#system(target_cmd . " action write-chars %s", [text_to_paste])
+    call slime#common#system(target_cmd . " action write 27 91 50 48 49 126", [])
     if has_crlf
-      call system("zellij " . target_session . " action write 10")
+      call slime#common#system(target_cmd . " action write 10", [])
     endif
   else
-    call system("zellij " . target_session . " action write-chars " . shellescape(text_to_paste))
+    call slime#common#system(target_cmd . " action write-chars %s", [text_to_paste])
   endif
 
   if a:config["relative_pane"] != "current"
-    call system("zellij " . target_session . " action move-focus " . shellescape(a:config["relative_move_back"]))
+    call slime#common#system(target_cmd . " action move-focus %s", [a:config["relative_move_back"]])
   end
+endfunction
+
+" -------------------------------------------------
+
+function! s:target_cmd(session_id)
+  if a:session_id != "current"
+    return "zellij -s " . shellescape(a:session_id)
+  end
+  return "zellij"
 endfunction
 


### PR DESCRIPTION
Previously, all function that shelled out (`system`) had to be mindful of using `shellescape` properly.

But using `slime#common#system`, they can now:
- use `printf` templating
- have all their arguments automatically `shellescape`d

Also, a new private `target_cmd` was introduced to simplify redundant setup of many-use commands.