### PR TITLE
Refactor: bracketed paste

### DIFF
--- a/assets/doc/targets/kitty.md
+++ b/assets/doc/targets/kitty.md
@@ -36,3 +36,17 @@ allow_remote_control yes
 listen_on unix:/tmp/mykitty
 ```
 
+### bracketed-paste
+
+Some REPLs can interfere with your text pasting. The [bracketed-paste](https://cirw.in/blog/bracketed-paste) mode exists to allow raw pasting.
+
+`kitty` supports bracketed-paste, use:
+
+```vim
+let g:slime_bracketed_paste = 1
+" or
+let b:slime_bracketed_paste = 1
+```
+
+(It is disabled by default because it can create issues with ipython; see [#265](https://github.com/jpalardy/vim-slime/pull/265)).
+

--- a/assets/doc/targets/tmux.md
+++ b/assets/doc/targets/tmux.md
@@ -53,14 +53,16 @@ Or, more reliably, by leveraging [a special token](http://man.openbsd.org/OpenBS
 let g:slime_default_config = {"socket_name": "default", "target_pane": "{last}"}
 ```
 
-tmux bracketed-paste
+### bracketed-paste
 
 Some REPLs can interfere with your text pasting. The [bracketed-paste](https://cirw.in/blog/bracketed-paste) mode exists to allow raw pasting.
 
-`tmux` knows how to handle bracketed-paste, use:
+`tmux` supports bracketed-paste, use:
 
 ```vim
 let g:slime_bracketed_paste = 1
+" or
+let b:slime_bracketed_paste = 1
 ```
 
 (It is disabled by default because it can create issues with ipython; see [#265](https://github.com/jpalardy/vim-slime/pull/265)).

--- a/assets/doc/targets/wezterm.md
+++ b/assets/doc/targets/wezterm.md
@@ -26,3 +26,17 @@ a split wezterm window with a REPL to the right it could look like this:
 let g:slime_default_config = {"pane_direction": "right"}
 ```
 
+### bracketed-paste
+
+Some REPLs can interfere with your text pasting. The [bracketed-paste](https://cirw.in/blog/bracketed-paste) mode exists to allow raw pasting.
+
+`wezterm` supports bracketed-paste, use:
+
+```vim
+let g:slime_bracketed_paste = 1
+" or
+let b:slime_bracketed_paste = 1
+```
+
+(It is disabled by default because it can create issues with ipython; see [#265](https://github.com/jpalardy/vim-slime/pull/265)).
+

--- a/assets/doc/targets/zellij.md
+++ b/assets/doc/targets/zellij.md
@@ -30,3 +30,17 @@ a split zellij window with a REPL to the right it could look like this:
 let g:slime_default_config = {"session_id": "current", "relative_pane": "right"}
 ```
 
+### bracketed-paste
+
+Some REPLs can interfere with your text pasting. The [bracketed-paste](https://cirw.in/blog/bracketed-paste) mode exists to allow raw pasting.
+
+`zellij` supports bracketed-paste, use:
+
+```vim
+let g:slime_bracketed_paste = 1
+" or
+let b:slime_bracketed_paste = 1
+```
+
+(It is disabled by default because it can create issues with ipython; see [#265](https://github.com/jpalardy/vim-slime/pull/265)).
+

--- a/autoload/slime/common.vim
+++ b/autoload/slime/common.vim
@@ -47,3 +47,18 @@ function! slime#common#system(cmd_template, args, ...)
   endif
   return system(cmd, a:1)
 endfunction
+
+function! slime#common#bracketed_paste(text)
+  let bracketed_paste = slime#config#resolve("bracketed_paste")
+
+  let [text_to_paste, has_crlf] = [a:text, 0]
+  if bracketed_paste
+    if a:text[-2:] == "\r\n"
+      let [text_to_paste, has_crlf] = [a:text[:-3], 1]
+    elseif a:text[-1:] == "\r" || a:text[-1:] == "\n"
+      let [text_to_paste, has_crlf] = [a:text[:-2], 1]
+    endif
+  endif
+
+  return [bracketed_paste, text_to_paste, has_crlf]
+endfunction

--- a/autoload/slime/common.vim
+++ b/autoload/slime/common.vim
@@ -51,14 +51,12 @@ endfunction
 function! slime#common#bracketed_paste(text)
   let bracketed_paste = slime#config#resolve("bracketed_paste")
 
-  let [text_to_paste, has_crlf] = [a:text, 0]
-  if bracketed_paste
-    if a:text[-2:] == "\r\n"
-      let [text_to_paste, has_crlf] = [a:text[:-3], 1]
-    elseif a:text[-1:] == "\r" || a:text[-1:] == "\n"
-      let [text_to_paste, has_crlf] = [a:text[:-2], 1]
-    endif
+  if bracketed_paste == 0
+    return [bracketed_paste, a:text, 0]
   endif
+
+  let text_to_paste = substitute(a:text, '\(\r\n\|\r\|\n\)$', '', '')
+  let has_crlf = strlen(a:text) != strlen(text_to_paste)
 
   return [bracketed_paste, text_to_paste, has_crlf]
 endfunction

--- a/autoload/slime/common.vim
+++ b/autoload/slime/common.vim
@@ -36,5 +36,14 @@ endfunction
 
 function! slime#common#system(cmd_template, args, ...)
   let escaped_args = map(copy(a:args), "shellescape(v:val)")
-  return call('system', [call('printf', [a:cmd_template] + escaped_args)] + a:000)
+  let cmd = call('printf', [a:cmd_template] + escaped_args)
+
+  if slime#config#resolve("debug")
+    echom "slime system: " . cmd
+  endif
+
+  if a:0 == 0
+    return system(cmd)
+  endif
+  return system(cmd, a:1)
 endfunction

--- a/autoload/slime/config.vim
+++ b/autoload/slime/config.vim
@@ -4,6 +4,7 @@ let g:slime_config_defaults["target"] = "screen"
 let g:slime_config_defaults["preserve_curpos"] = 1
 let g:slime_config_defaults["paste_file"] = expand("$HOME/.slime_paste")
 let g:slime_config_defaults["bracketed_paste"] = 0
+let g:slime_config_defaults["debug"] = 0
 
 " -------------------------------------------------
 

--- a/autoload/slime/targets/kitty.vim
+++ b/autoload/slime/targets/kitty.vim
@@ -11,15 +11,9 @@ function! slime#targets#kitty#config() abort
 endfunction
 
 function! slime#targets#kitty#send(config, text)
-  let bracketed_paste = slime#config#resolve("bracketed_paste")
+  let [bracketed_paste, text_to_paste, _has_crlf] = slime#common#bracketed_paste(a:text)
 
-  let [text_to_paste, has_crlf] = [a:text, 0]
   if bracketed_paste
-    if a:text[-2:] == "\r\n"
-      let [text_to_paste, has_crlf] = [a:text[:-3], 1]
-    elseif a:text[-1:] == "\r" || a:text[-1:] == "\n"
-      let [text_to_paste, has_crlf] = [a:text[:-2], 1]
-    endif
     let text_to_paste = "\e[200~" . text_to_paste . "\e[201~"
   endif
 

--- a/autoload/slime/targets/kitty.vim
+++ b/autoload/slime/targets/kitty.vim
@@ -11,7 +11,7 @@ function! slime#targets#kitty#config() abort
 endfunction
 
 function! slime#targets#kitty#send(config, text)
-  let [bracketed_paste, text_to_paste, _has_crlf] = slime#common#bracketed_paste(a:text)
+  let [bracketed_paste, text_to_paste, has_crlf] = slime#common#bracketed_paste(a:text)
 
   if bracketed_paste
     let text_to_paste = "\e[200~" . text_to_paste . "\e[201~"
@@ -19,6 +19,11 @@ function! slime#targets#kitty#send(config, text)
 
   let target_cmd = s:target_cmd(a:config["listen_on"])
   call slime#common#system(target_cmd . " send-text --match id:%s --stdin", [a:config["window_id"]], text_to_paste)
+
+  " trailing newline
+  if has_crlf
+    call slime#common#system(target_cmd . " send-text --match id:%s --stdin", [a:config["window_id"]], "\n")
+  endif
 endfunction
 
 " -------------------------------------------------

--- a/autoload/slime/targets/tmux.vim
+++ b/autoload/slime/targets/tmux.vim
@@ -12,16 +12,7 @@ endfunction
 
 function! slime#targets#tmux#send(config, text)
   let target_cmd = s:target_cmd(a:config["socket_name"])
-  let bracketed_paste = slime#config#resolve("bracketed_paste")
-
-  let [text_to_paste, has_crlf] = [a:text, 0]
-  if bracketed_paste
-    if a:text[-2:] == "\r\n"
-      let [text_to_paste, has_crlf] = [a:text[:-3], 1]
-    elseif a:text[-1:] == "\r" || a:text[-1:] == "\n"
-      let [text_to_paste, has_crlf] = [a:text[:-2], 1]
-    endif
-  endif
+  let [bracketed_paste, text_to_paste, has_crlf] = slime#common#bracketed_paste(a:text)
 
   " reasonable hardcode, will become config if needed
   let chunk_size = 1000

--- a/autoload/slime/targets/wezterm.vim
+++ b/autoload/slime/targets/wezterm.vim
@@ -10,16 +10,7 @@ function! slime#targets#wezterm#config() abort
 endfunction
 
 function! slime#targets#wezterm#send(config, text)
-  let bracketed_paste = slime#config#resolve("bracketed_paste")
-
-  let [text_to_paste, has_crlf] = [a:text, 0]
-  if bracketed_paste
-    if a:text[-2:] == "\r\n"
-      let [text_to_paste, has_crlf] = [a:text[:-3], 1]
-    elseif a:text[-1:] == "\r" || a:text[-1:] == "\n"
-      let [text_to_paste, has_crlf] = [a:text[:-2], 1]
-    endif
-  endif
+  let [bracketed_paste, text_to_paste, has_crlf] = slime#common#bracketed_paste(a:text)
 
   if bracketed_paste
     call slime#common#system("wezterm cli send-text --pane-id=%s", [a:config["pane_id"]], text_to_paste)

--- a/autoload/slime/targets/zellij.vim
+++ b/autoload/slime/targets/zellij.vim
@@ -25,16 +25,7 @@ function! slime#targets#zellij#send(config, text)
   if a:config["relative_pane"] != "current"
     call slime#common#system(target_cmd . " action move-focus %s",  [a:config["relative_pane"]])
   end
-  let bracketed_paste = slime#config#resolve("bracketed_paste")
-
-  let [text_to_paste, has_crlf] = [a:text, 0]
-  if bracketed_paste
-    if a:text[-2:] == "\r\n"
-      let [text_to_paste, has_crlf] = [a:text[:-3], 1]
-    elseif a:text[-1:] == "\r" || a:text[-1:] == "\n"
-      let [text_to_paste, has_crlf] = [a:text[:-2], 1]
-    endif
-  endif
+  let [bracketed_paste, text_to_paste, has_crlf] = slime#common#bracketed_paste(a:text)
 
   if bracketed_paste
     call slime#common#system(target_cmd . " action write 27 91 50 48 48 126", [])

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -121,8 +121,8 @@ Use bracketed-paste mode~
 Sometimes REPL are too smart for their own good, e.g. autocompleting a bracket
 that should not be autocompleted when pasting code from a file. In this case
 it can be useful to rely on bracketed-paste
-(https://cirw.in/blog/bracketed-paste). Luckily, tmux knows how to handle
-that. See tmux's manual.
+(https://cirw.in/blog/bracketed-paste). Luckily, some targets (https://github.com/jpalardy/vim-slime#targets) know how to handle
+that.
 
 You can enable bracketed-paste using eiter
 >
@@ -321,10 +321,6 @@ g:slime_default_config	Set to dictionary of pre-filled prompt answer. See
 						*g:slime_dont_ask_default*
 g:slime_dont_ask_default	Works with g:slime_default_config. See
 			the README for details: https://github.com/jpalardy/vim-slime
-
-g:slime_bracketed_paste Set to non zero value to enable bracketed paste in
-                        tmux. See |slime-tmux| or the README for details: 
-                        https://github.com/jpalardy/vim-slime 
 
 Mappings~
 

--- a/ftplugin/haskell/README.md
+++ b/ftplugin/haskell/README.md
@@ -9,16 +9,20 @@ To support older GHC versions, code is processed in order to comply with the
 syntax rules that are specific to interactive mode. For instance when sending
 the following snippet to `ghci`:
 
-    -- make in triplicate
-    f :: a -> [a]
-    f = replicate 3
+```haskell
+-- make in triplicate
+f :: a -> [a]
+f = replicate 3
+```
 
 This translates to the following:
 
-    :{
-    let f :: a -> [a]
-        f = replicate 3
-    :}
+```haskell
+:{
+let f :: a -> [a]
+    f = replicate 3
+:}
+```
 
 Some of this behavior can be selectively turned off so that what is run is more
 faithful to the actual code in your buffer, but requires a recent enough GHC:
@@ -37,15 +41,19 @@ Haskell and I write these script files as if I were writing in `ghci`, sometimes
 the syntax translation would get in the way. E.g. I would write a function call
 to test a certain function and check it's type:
 
-    (++) "This is a: " "TEST"
-    :type (++)
+```haskell
+(++) "This is a: " "TEST"
+:type (++)
+```
 
 and it get translated to:
 
-    :{
-    let (++) "This is a: " "TEST"
-        :type (++)
-    :}
+```haskell
+:{
+let (++) "This is a: " "TEST"
+    :type (++)
+:}
+```
 
 which is not what I wanted obviously.
 
@@ -54,7 +62,9 @@ in vim is set to `haskell.script`. If you want access to this handler call `set
 ft=haskell.script` or create a new ftdetect file which does this for you for a
 certain file extension. For instance, I have:
 
-    au BufRead,BufNewFile,BufNew *.hss setl ft=haskell.script
+```vim
+au BufRead,BufNewFile,BufNew *.hss setl ft=haskell.script
+```
 
 in `~/.vim/ftdetect/hss.vim`.
 

--- a/ftplugin/python/README.md
+++ b/ftplugin/python/README.md
@@ -10,24 +10,25 @@ interpreter.
 error-free pasting. In order for vim-slime to make use of this feature for
 Python buffers, you need to set the corresponding variable in your .vimrc:
 
-    let g:slime_python_ipython = 1
+```vim
+let g:slime_python_ipython = 1
+```
 
 Note: if you're using IPython 5, you _need_ to set `g:slime_python_ipython` for
 pasting to work correctly.
 
-#### Note for `tmux` users
+#### Note for `tmux`, `kitty`, `wezterm`, `zellij` users
 
-If you're using `tmux`, it's better to _not_ set `g:slime_python_ipython`, but
-instead use [bracketed-paste](https://cirw.in/blog/bracketed-paste) by setting 
-either
+If your target supports [bracketed-paste](https://cirw.in/blog/bracketed-paste), that's
+a better option than `g:slime_python_ipython`:
 
-    let g:slime_bracketed_paste = 1
+```vim
+" in .vimrc
+let g:slime_bracketed_paste = 1
+" or, in ftplugin/python.vim
+let b:slime_bracketed_paste = 1
+```
 
-in your `vimrc` or
+This lets your target deal with all the problems with indentation and avoids depending `%cpaste`,
+which occassionally causes issues (e.g., [#327](https://github.com/jpalardy/vim-slime/issues/327))
 
-    let b:slime_bracketed_paste = 1
-
-in `ftplugin/python.vim`.
-
-This lets `tmux` deal with all the problems with indentation and avoids depending 
-`%cpaste`, which occassionally causes issues (e.g., [#327](https://github.com/jpalardy/vim-slime/issues/327))

--- a/ftplugin/scala/README.md
+++ b/ftplugin/scala/README.md
@@ -1,19 +1,22 @@
 
 ### Scala
 
-By default, vim-slime expects to use the base Scala REPL
+By default, `vim-slime` expects to use the base Scala REPL
 (or [sbt](https://www.scala-sbt.org/) console).
 
 Scala's [Ammonite REPL](https://ammonite.io) is an improved Scala REPL,
 similar to IPython. It does not have a `:paste` command like the default
 REPL, but rather wraps multi-line expressions in curly braces.
 
-To use Ammonite with vim-slime, set the following variable in your .vimrc:
+To use Ammonite with `vim-slime`, set the following variable in your `.vimrc`:
 
-    let g:slime_scala_ammonite = 1
+```vim
+let g:slime_scala_ammonite = 1
+```
 
 Note that although Scala is usually installed on a per-project basis
 through tools like sbt, setting `let g:slime_scala_ammonite = 1`
 is a global change to your Vim setup.
+
 You will need to unset the variable in your `.vimrc` before starting Vim
 if you decide not to use Ammonite for a particular project.


### PR DESCRIPTION
Multiple targets are now supporting bracketed paste, but the logic wasn't centralized (until now).

### Discussion

- less logic in each targets
- added `slime_debug` mode to log `system` commands
- simplified `bracketed_paste` logic