### PR TITLE
kitty: get listen_on from environment if available

### DIFF
--- a/assets/doc/targets/kitty.md
+++ b/assets/doc/targets/kitty.md
@@ -34,7 +34,11 @@ listen_on unix:/tmp/mykitty
 
 ### SSH
 
-For slime use over ssh, you can also [forward the remote control](https://sw.kovidgoyal.net/kitty/kittens/ssh/#opt-kitten-ssh.forward_remote_control). Although note the additional security concerns: **this should only be done on trusted remote hosts**.
+For slime use over ssh, you can also [forward the remote control](https://sw.kovidgoyal.net/kitty/kittens/ssh/#opt-kitten-ssh.forward_remote_control).
+
+
+Note the additional security concerns, however: **this should only be done on
+trusted remote hosts**.
 
 ### bracketed-paste
 

--- a/assets/doc/targets/kitty.md
+++ b/assets/doc/targets/kitty.md
@@ -9,19 +9,15 @@ let g:slime_target = "kitty"
 
 When you invoke `vim-slime` for the first time, you will be prompted for more configuration.
 
-kitty target window
+`kitty target window`
 
-    This is the id of the kitty window that you wish to target.
-    See e.g. the value of $KITTY_WINDOW_ID in the target window.
+    This is the id of the kitty window that you wish to target. See e.g. the
+    value of $KITTY_WINDOW_ID in the target window.
 
-kitty listen on
+`kitty listen on`
 
-    Specifies where kitty should listen to control messages.
-    See e.g. the value of $KITTY_LISTEN_ON in the target window.
-
-    Can be left blank if:
-    - KITTY_LISTEN_ON is exported in the shell running vim
-    - running vim (but not nvim) inside kitty
+    Specifies where kitty should listen to control messages, by default the
+    value of $KITTY_LISTEN_ON in the target window.
 
 To work properly, `kitty` must also be started with the following options:
 
@@ -35,6 +31,8 @@ See more [here](https://sw.kovidgoyal.net/kitty/remote-control.html). This can a
 allow_remote_control yes
 listen_on unix:/tmp/mykitty
 ```
+
+For slime use over ssh, you can also [forward the remote control](https://sw.kovidgoyal.net/kitty/kittens/ssh/#opt-kitten-ssh.forward_remote_control). Although note the additional security concerns: **this should only be done on trusted remote hosts**.
 
 ### bracketed-paste
 

--- a/assets/doc/targets/kitty.md
+++ b/assets/doc/targets/kitty.md
@@ -32,6 +32,8 @@ allow_remote_control yes
 listen_on unix:/tmp/mykitty
 ```
 
+### SSH
+
 For slime use over ssh, you can also [forward the remote control](https://sw.kovidgoyal.net/kitty/kittens/ssh/#opt-kitten-ssh.forward_remote_control). Although note the additional security concerns: **this should only be done on trusted remote hosts**.
 
 ### bracketed-paste

--- a/autoload/slime/targets/kitty.vim
+++ b/autoload/slime/targets/kitty.vim
@@ -1,16 +1,13 @@
 
 function! slime#targets#kitty#config() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"window_id": 1, "listen_on": ""}
+    let b:slime_config = {"window_id": 1, "listen_on": $KITTY_LISTEN_ON}
   end
   let b:slime_config["window_id"] = str2nr(slime#common#system("kitty @ select-window --self", []))
   if v:shell_error || b:slime_config["window_id"] == $KITTY_WINDOW_ID
     let b:slime_config["window_id"] = input("kitty window_id: ", b:slime_config["window_id"])
   endif
-  let b:slime_config["listen_on"] = $KITTY_LISTEN_ON
-  if b:slime_config["listen_on"] == ""
-    let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
-  endif
+  let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
 endfunction
 
 function! slime#targets#kitty#send(config, text)

--- a/autoload/slime/targets/kitty.vim
+++ b/autoload/slime/targets/kitty.vim
@@ -7,7 +7,10 @@ function! slime#targets#kitty#config() abort
   if v:shell_error || b:slime_config["window_id"] == $KITTY_WINDOW_ID
     let b:slime_config["window_id"] = input("kitty window_id: ", b:slime_config["window_id"])
   endif
-  let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
+  let b:slime_config["listen_on"] = $KITTY_LISTEN_ON
+  if b:slime_config["listen_on"] == ""
+    let b:slime_config["listen_on"] = input("kitty listen on: ", b:slime_config["listen_on"])
+  endif
 endfunction
 
 function! slime#targets#kitty#send(config, text)


### PR DESCRIPTION
This checks for `KITTY_LISTEN_ON` as an environment variable and uses if set, which [ the docs](https://github.com/jpalardy/vim-slime/blob/main/assets/doc/targets/kitty.md) say is already done. But the code doesn't actually seem to read the environment variable. Also not sure why the docs suggests this will only work in vim, this works fine in nvim

This is also my first lines of vim script ever, so make sure I haven't done anything too stupid - namely I hope the check for empty string is all that's needed when setting `listen_on`