### PR TITLE
Track channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To control exactly what is sent, you can manually select text before calling `vi
 
 ## Vim Style Mappings
 
-To use vim-style mappings, such as operator + motion or operator + text object see the appropriate [advanced configuration secltion]
+To use vim-style mappings, such as operator+motion or operator+text object see the appropriate [section of the advanced configuration documentation](https://github.com/jam1015/vim-slime/blob/track_channels/assets/doc/advanced.md#vim-style-mappings).
 
 Config prompt
 --------------

--- a/README.md
+++ b/README.md
@@ -84,25 +84,9 @@ The current paragraph — what would be selected if you typed `vip` — is autom
 
 To control exactly what is sent, you can manually select text before calling `vim-slime`.
 
-## Vim-like mappings
+## Vim Style Mappings
 
-To use vim-style mappings, such as operator + motion or operator + text object see:
-
-```vim
-"disables mappings from previous usage section
-let g:slime_no_mappings = 1
-
-"send visual selection
-xmap <leader>s <Plug>SlimeRegionSend
-
-"send based on motion or text object
-nmap <leader>s <Plug>SlimeMotionSend
-
-"send line
-nmap <leader>ss <Plug>SlimeLineSend
-```
-
-Of course these mappings are just examples; you can set them according to your preference.
+To use vim-style mappings, such as operator + motion or operator + text object see the appropriate [advanced configuration secltion]
 
 Config prompt
 --------------

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To use vim-style mappings:
 let g:slime_no_mappings = 1
 
 "send visual selection
-xmap <leader>s <Plug>SlimeRegionSend 
+xmap <leader>s <Plug>SlimeRegionSend
 
 "send based on motion or text object
 nmap <leader>s <Plug>SlimeMotionSend

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ nmap <leader>s <Plug>SlimeMotionSend
 nmap <leader>ss <Plug>SlimeLineSend
 ```
 
+Of course these mappings are just examples; you can set them according to your preference.
+
 Config prompt
 --------------
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To control exactly what is sent, you can manually select text before calling `vi
 
 ## Vim-like mappings
 
-To use vim-style mappings:
+To use vim-style mappings, such as operator + motion or operator + text object see:
 
 ```vim
 "disables mappings from previous usage section

--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ The current paragraph — what would be selected if you typed `vip` — is autom
 
 To control exactly what is sent, you can manually select text before calling `vim-slime`.
 
+## Vim-like mappings
+
+To use vim-style mappings:
+
+```vim
+"disables mappings from previous usage section
+let g:slime_no_mappings = 1
+
+"send visual selection
+xmap <leader>s <Plug>SlimeRegionSend 
+
+"send based on motion or text object
+nmap <leader>s <Plug>SlimeMotionSend
+
+"send line
+nmap <leader>ss <Plug>SlimeLineSend
+```
+
 Config prompt
 --------------
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To control exactly what is sent, you can manually select text before calling `vi
 
 ## Vim Style Mappings
 
-To use vim-style mappings, such as operator+motion or operator+text object see the appropriate [section of the advanced configuration documentation](https://github.com/jam1015/vim-slime/blob/track_channels/assets/doc/advanced.md#vim-style-mappings).
+To use vim-style mappings, such as operator+motion or operator+text object see the appropriate [section of the advanced configuration documentation](assets/doc/advanced.md#vim-style-mappings).
 
 Config prompt
 --------------

--- a/assets/doc/advanced.md
+++ b/assets/doc/advanced.md
@@ -81,7 +81,7 @@ let g:slime_preserve_curpos = 0
 
 ## Send Delimited Cells
 
-If you want to send blocks of code between two delimiters, emulating the cell-like mode of REPL environments like ipython, matlab, etc., you can set the cell delimiter to the `b:slime_cell_delimiter` or `g:slime_cell_delimiter` variable and use the `<Plug>SlimeSendCell` mapping to send the block of code. For example, if you are using ipython you could use the following:
+If you want to send blocks of code between two delimiters, emulating the cell-like mode of REPL environments like ipython, matlab, etc., you can set the cell delimiter to any buffer-local variable `b:slime_cell_delimiter` or global `g:slime_cell_delimiter` variable and use the `<Plug>SlimeSendCell` mapping to send the block of code. For example, if you are using ipython you could use the following:
 
 ```vim
 let g:slime_cell_delimiter = "#%%"

--- a/assets/doc/advanced.md
+++ b/assets/doc/advanced.md
@@ -33,7 +33,27 @@ nmap <c-c><c-c> <Plug>SlimeParagraphSend
 nmap <c-c>v     <Plug>SlimeConfig
 ```
 
-## Vim Style Mappings
+### Vim Style Mappings
+
+Example of how to set vim-style mappings:
+
+```vim
+"disables default bindings
+let g:slime_no_mappings = 1
+
+"send visual selection
+xmap <leader>s <Plug>SlimeRegionSend
+
+"send based on motion or text object
+nmap <leader>s <Plug>SlimeMotionSend
+
+"send line
+nmap <leader>ss <Plug>SlimeLineSend
+```
+
+Of course these mappings are just examples; you can set them according to your preference.
+
+## Default Config
 
 If you want `vim-slime` to prefill the prompt answers, you can set a default configuration:
 
@@ -51,13 +71,17 @@ If you want `vim-slime` to bypass the prompt and use the specified default confi
 let g:slime_dont_ask_default = 1
 ```
 
+## Don't Restore Cursor Position
+
 By default, `vim-slime` will try to restore your cursor position after it runs. If you don't want that behavior, unset the `g:slime_preserve_curpos` option:
 
 ```vim
 let g:slime_preserve_curpos = 0
 ```
 
-If you want to send blocks of code between two delimiters, emulating the cell-like mode of REPL environments like ipython, matlab, etc., you can set the cell delimiter on the `g:slime_cell_delimiter` variable and use the `<Plug>SlimeSendCell` mapping to send the block of code. For example, if you are using ipython you could use the following:
+## Send Delimited Cells
+
+If you want to send blocks of code between two delimiters, emulating the cell-like mode of REPL environments like ipython, matlab, etc., you can set the cell delimiter to the `b:slime_cell_delimiter` or `g:slime_cell_delimiter` variable and use the `<Plug>SlimeSendCell` mapping to send the block of code. For example, if you are using ipython you could use the following:
 
 ```vim
 let g:slime_cell_delimiter = "#%%"

--- a/assets/doc/advanced.md
+++ b/assets/doc/advanced.md
@@ -2,6 +2,7 @@
 Advanced Configuration
 ----------------------
 
+## Mappings
 If you need this, you might as well refer to [the code](https://github.com/jpalardy/vim-slime/blob/master/plugin/slime.vim#L233-L245).
 The code is not as complicated as you think. 😄
 
@@ -18,6 +19,8 @@ xmap <c-c><c-c> <Plug>SlimeRegionSend
 nmap <c-c><c-c> <Plug>SlimeParagraphSend
 nmap <c-c>v     <Plug>SlimeConfig
 ```
+
+## Vim Style Mappings
 
 If you want `vim-slime` to prefill the prompt answers, you can set a default configuration:
 

--- a/assets/doc/advanced.md
+++ b/assets/doc/advanced.md
@@ -53,7 +53,7 @@ nmap <leader>ss <Plug>SlimeLineSend
 
 Of course these mappings are just examples; you can set them according to your preference.
 
-## Default Config
+## Set a Custom Default Config
 
 If you want `vim-slime` to prefill the prompt answers, you can set a default configuration:
 

--- a/assets/doc/advanced.md
+++ b/assets/doc/advanced.md
@@ -85,7 +85,7 @@ If you want to send blocks of code between two delimiters, emulating the cell-li
 
 ```vim
 let g:slime_cell_delimiter = "#%%"
-nmap <leader>s <Plug>SlimeSendCell
+nmap <leader>sc <Plug>SlimeSendCell
 ```
 
 ⚠️  it's recommended to use `b:slime_cell_delimiter` and set the variable in `ftplugin` for each relevant filetype.

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -7,7 +7,7 @@
 let g:slime_target = "neovim"
 ```
 
-When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, previously opened terminals will be suggested.
+When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested.
 
 To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
 
@@ -33,7 +33,7 @@ Another way to easily see the `PID` and job ID is to override the status bar of 
 
 See `h:statusline` in Vim's documentiation for more details.
 
-If you are using a plugin to manage your status line, see plugin's documentation to see how to confiugre the status line to display `b:terminal_job_id` and `b:terminal_job_pid`.
+If you are using a plugin to manage your status line, see that plugin's documentation to see how to confiugre the status line to display `b:terminal_job_id` and `b:terminal_job_pid`.
 
 You can also specify a function to query the jobid as
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -7,13 +7,33 @@
 let g:slime_target = "neovim"
 ```
 
-When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default.
+When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, previously opened terminals will be presented.
 
-To manually check the right value of `job-id` to use, try:
+To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
 
+```vim
+let g:slime_input_pid=1
+```
+
+On Windows Neovim assigns a PID as well.
+
+To manually check the right value of `job-id`  (but not `PID`) try:
+
+```vim
     echo &channel
+```
 
 from the buffer running your terminal.
+
+Another way to easily see the `PID` and job ID is to override the status bar of terminals to show the job id and PID.
+
+```vim
+ autocmd TermOpen * setlocal statusline=%{bufname()}%=id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
+```
+
+See `h:statusline` in Vim's documentiation for more details.
+
+If you are using a plugin to manage your status line, see plugin's documentation to see how to confiugre the status line to display `b:terminal_job_id` and `b:terminal_job_pid`.
 
 You can also specify a function to query the jobid as
 
@@ -22,4 +42,3 @@ vim.g.slime_get_jobid = function()
   -- some way to select and return jobid
 end
 ```
-

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -7,7 +7,7 @@
 let g:slime_target = "neovim"
 ```
 
-When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, previously opened terminals will be presented.
+When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, previously opened terminals will be suggested.
 
 To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -11,35 +11,35 @@ function! s:_EscapeText(text)
       let result = call(override_fn, [a:text])
     elseif exists("*" . escape_text_fn)
       let result = call(escape_text_fn, [a:text])
-    end
-  end
+    endif
+  endif
 
   " use a:text if the ftplugin didn't kick in
   if !exists("result")
     let result = a:text
-  end
+  endif
 
   " return an array, regardless
   if type(result) == type("")
     return [result]
   else
     return result
-  end
+  endif
 endfunction
 
 function! s:SlimeGetConfig()
   " b:slime_config already configured...
   if exists("b:slime_config")
     return
-  end
+  endif
   " assume defaults, if they exist
   if exists("g:slime_default_config")
     let b:slime_config = g:slime_default_config
-  end
+  endif
   " skip confirmation, if configured
   if exists("g:slime_dont_ask_default") && g:slime_dont_ask_default
     return
-  end
+  endif
   " prompt user
   call s:SlimeDispatch('config')
 endfunction
@@ -141,7 +141,7 @@ function! slime#send(text)
       endif
     else
       call s:SlimeDispatch('send', b:slime_config, piece)
-    end
+    endif
   endfor
 endfunction
 
@@ -157,7 +157,7 @@ function! s:SlimeDispatch(name, ...)
   let override_fn = "SlimeOverride" . slime#common#capitalize(a:name)
   if exists("*" . override_fn)
     return call(override_fn, a:000)
-  end
+  endif
   return call("slime#targets#" . slime#config#resolve("target") . "#" . a:name, a:000)
 endfunction
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -10,7 +10,6 @@ function! slime#targets#neovim#config() abort
     endif
   endif
 
-
   if !exists("b:slime_config")
     let last_pid = get(get(g:slime_last_channel, -1, {}), 'pid', '')
     let last_job = get(get(g:slime_last_channel, -1, {}), 'jobid', '')

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -17,7 +17,7 @@ function! slime#targets#neovim#config() abort
     let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
   endif
 
-  "include option to input pid
+  " include option to input pid
   if exists("g:slime_input_pid") && g:slime_input_pid
     let pid_in = input("pid: ", str2nr(jobpid(b:slime_config["jobid"])))
     let id_in = s:translate_pid_to_id(pid_in)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -73,7 +73,7 @@ function! slime#targets#neovim#SlimeClearChannel()
     let bufinfo = s:get_filter_bufinfo()
 
 
-    " tests ifusing a version of Neovim that 
+    " tests if using a version of Neovim that 
     " doesn't automatically close bufers when closed
     " or there is no autocommand that does that
     if len(bufinfo) == len(g:slime_last_channel)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -80,8 +80,6 @@ function! slime#targets#neovim#SlimeClearChannel()
 
     call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
 
-    echom "cleari channel: "..join(g:slime_last_channel, ",")
-
   endif
 endfunction
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -51,7 +51,6 @@ function! slime#targets#neovim#SlimeAddChannel()
     let g:slime_last_channel = [{'jobid': &channel, 'pid': b:terminal_job_pid}]
   else
     call add(g:slime_last_channel, {'jobid': &channel, 'pid': b:terminal_job_pid})
-    echom "adding channel: "..join(g:slime_last_channel, ",")
   endif
 endfunction
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -1,13 +1,26 @@
 
 function! slime#targets#neovim#config() abort
   if !exists("b:slime_config")
-    let b:slime_config = {"jobid": get(g:, "slime_last_channel", "")}
-  end
-  if exists("g:slime_get_jobid")
-    let b:slime_config["jobid"] = g:slime_get_jobid()
+    let last_pid = get(get(g:slime_last_channel, -1, {}), 'pid', '')
+    let last_job = get(get(g:slime_last_channel, -1, {}), 'jobid', '')
+    let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
+  endif
+
+  if exists("g:slime_input_pid") && g:slime_input_pid
+    let pid_in = input("pid: ", str2nr(jobpid(b:slime_config["jobid"])))
+    let id_in = s:translate_pid_to_id(pid_in)
   else
-    let b:slime_config["jobid"] = input("jobid: ", b:slime_config["jobid"])
-  end
+    if exists("g:slime_get_jobid")
+      let id_in = g:slime_get_jobid()
+    else
+      let id_in = input("jobid: ", str2nr(b:slime_config["jobid"]))
+      let id_in = str2nr(id_in)
+    endif
+    let pid_in = s:translate_id_to_pid(id_in)
+  endif
+
+  let b:slime_config["jobid"] = id_in
+  let b:slime_config["pid"] = pid_in
 endfunction
 
 function! slime#targets#neovim#send(config, text)
@@ -19,7 +32,57 @@ function! slime#targets#neovim#send(config, text)
   " if b:slime_config is {"jobid": ""} and not configured
   " then unset it for automatic configuration next time
   if b:slime_config["jobid"]  == ""
-      unlet b:slime_config
+    unlet b:slime_config
   endif
 endfunction
 
+function! slime#targets#neovim#SlimeAddChannel()
+  if !exists("g:slime_last_channel")
+    let g:slime_last_channel = [{'jobid': &channel, 'pid': b:terminal_job_pid}]
+  else
+    call add(g:slime_last_channel, {'jobid': &channel, 'pid': b:terminal_job_pid})
+  endif
+endfunction
+
+function slime#targets#neovim#SlimeClearChannel()
+  if !exists("g:slime_last_channel")
+    return
+  elseif len(g:slime_last_channel) == 1
+    unlet g:slime_last_channel
+  else
+    let bufinfo = getbufinfo()
+    call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id") && has_key(val['variables'], "terminal_job_pid") && !get(val['variables'],"terminal_closed",0)})
+    call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
+    call filter(g:slime_last_channel, {_, val -> index(bufinfo, val["jobid"]) >= 0})
+  endif
+endfunction
+
+" Sets the status line if the appropriate flags are enabled.
+function! slime#targets#neovim#SetStatusline()
+  if exists("g:override_status") && g:override_status
+    if exists("g:ruled_status") && g:ruled_status
+      setlocal statusline=%{bufname()}%=%-14.(%l,%c%V%)\ %P\ \|\ id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
+    else
+      setlocal statusline=%{bufname()}%=id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
+    endif
+  endif
+endfunction
+
+function! s:translate_pid_to_id(pid)
+  for ch in g:slime_last_channel
+    if ch['pid'] == a:pid
+      return ch['jobid']
+    endif
+  endfor
+  return -1
+endfunction
+
+function! s:translate_id_to_pid(id)
+  let pid_out = -1
+  try
+    let pid_out = jobpid(a:id)
+  catch /E900: Invalid channel id/
+    let pid_out = -1
+  endtry
+  return pid_out
+endfunction

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -115,5 +115,3 @@ function! s:translate_id_to_pid(id)
   endtry
   return pid_out
 endfunction
-
-

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -1,6 +1,7 @@
 
 function! slime#targets#neovim#config() abort
 
+  " unlet current config if its jobid doesn't exist
   if exists("b:slime_config")
     let bufinfo = s:get_filter_bufinfo()
     let current_jobid = get(b:slime_config, "jobid", "-1")
@@ -16,6 +17,7 @@ function! slime#targets#neovim#config() abort
     let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
   endif
 
+  "include option to input pid
   if exists("g:slime_input_pid") && g:slime_input_pid
     let pid_in = input("pid: ", str2nr(jobpid(b:slime_config["jobid"])))
     let id_in = s:translate_pid_to_id(pid_in)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -57,17 +57,6 @@ function slime#targets#neovim#SlimeClearChannel()
   endif
 endfunction
 
-" Sets the status line if the appropriate flags are enabled.
-function! slime#targets#neovim#SetStatusline()
-  if exists("g:override_status") && g:override_status
-    if exists("g:ruled_status") && g:ruled_status
-      setlocal statusline=%{bufname()}%=%-14.(%l,%c%V%)\ %P\ \|\ id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
-    else
-      setlocal statusline=%{bufname()}%=id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
-    endif
-  endif
-endfunction
-
 function! s:translate_pid_to_id(pid)
   for ch in g:slime_last_channel
     if ch['pid'] == a:pid

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -61,7 +61,7 @@ function! slime#targets#neovim#SlimeClearChannel()
 
   if !exists("g:slime_last_channel")
     if exists("b:slime_config")
-      unlet b:slime_config 
+      unlet b:slime_config
     endif
     return
   elseif len(g:slime_last_channel) == 1
@@ -72,9 +72,8 @@ function! slime#targets#neovim#SlimeClearChannel()
   else
     let bufinfo = s:get_filter_bufinfo()
 
-
-    " tests if using a version of Neovim that 
-    " doesn't automatically close bufers when closed
+    " tests if using a version of Neovim that
+    " doesn't automatically close buffers when closed
     " or there is no autocommand that does that
     if len(bufinfo) == len(g:slime_last_channel)
       call filter(bufinfo, {_, val -> val != current_buffer_jobid})
@@ -90,7 +89,7 @@ function! s:get_filter_bufinfo()
   "getting terminal buffers
 
   call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
-        \ && has_key(val['variables'], "terminal_job_pid") 
+        \ && has_key(val['variables'], "terminal_job_pid")
         \    && get(val,"listed",0)})
   " only need the job id
   call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -45,7 +45,5 @@ if slime#config#resolve("target") == "neovim"
     autocmd TermOpen * call slime#targets#neovim#SlimeAddChannel()
     " keeping track when terminals are closed
     autocmd TermClose * let b:terminal_closed = 1 | call slime#targets#neovim#SlimeClearChannel()
-    " setting status line to show job id and pid of terminal
-    autocmd TermOpen * call slime#targets#neovim#SetStatusline()
   augroup END
 endif

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -44,6 +44,6 @@ if slime#config#resolve("target") == "neovim"
     " keeping track of channels that are open
     autocmd TermOpen * call slime#targets#neovim#SlimeAddChannel()
     " keeping track when terminals are closed
-    autocmd TermClose * let b:terminal_closed = 1 | call slime#targets#neovim#SlimeClearChannel()
+    autocmd TermClose * call slime#targets#neovim#SlimeClearChannel()
   augroup END
 endif

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -41,6 +41,11 @@ endif
 if slime#config#resolve("target") == "neovim"
   augroup nvim_slime
     autocmd!
-    autocmd TermOpen * let g:slime_last_channel = &channel
+    " keeping track of channels that are open
+    autocmd TermOpen * call slime#targets#neovim#SlimeAddChannel()
+    " keeping track when terminals are closed
+    autocmd TermClose * let b:terminal_closed = 1 | call slime#targets#neovim#SlimeClearChannel()
+    " setting status line to show job id and pid of terminal
+    autocmd TermOpen * call slime#targets#neovim#SetStatusline()
   augroup END
-end
+endif


### PR DESCRIPTION
# Intro
I know that PRs are supposed to be monolithic.  This PR is fairly monolithic as it has one major change to the actual plugin, and seveal minor changes.

They are (in rough order of importance)

1. Improving the tracking of previously opened terminals for the Neovim target
2. Adding more details on use of vim-style mappings to the `README`
3. Expanding the `neovim` target `README` , including changes to reflect the new features in point 1.
4. Replacing `end` with `endif` in appropriate places.


# The Changes
Going point by point:

## Improving Terminal Tracking

In the current release, the last open terminal is kept track of with

```vim
  augroup nvim_slime
    autocmd!
    autocmd TermOpen * let g:slime_last_channel = &channel
  augroup END
```


This works, but forgets about previously opened terminals if multiple are opened.  This PR takes the approach:

```vim
  augroup nvim_slime
    autocmd!
    " keeping track of channels that are open
    autocmd TermOpen * call slime#targets#neovim#SlimeAddChannel()
    " keeping track when terminals are closed
    autocmd TermClose * call slime#targets#neovim#SlimeClearChannel()
  augroup END
```

Where `SlimeAddChannel` and `SlimeClearChannel` respectively add or remove channels from a variable stored as `g:slime_last_channel`


Here are the those functions:

```vim

function! slime#targets#neovim#SlimeAddChannel()
  if !exists("g:slime_last_channel")
    let g:slime_last_channel = [{'jobid': &channel, 'pid': b:terminal_job_pid}]
  else
    call add(g:slime_last_channel, {'jobid': &channel, 'pid': b:terminal_job_pid})
  endif
endfunction

function! slime#targets#neovim#SlimeClearChannel()
  let current_buffer_jobid = get(b:,"terminal_job_id",-1)

  if !exists("g:slime_last_channel")
    if exists("b:slime_config")
      unlet b:slime_config 
    endif
    return
  elseif len(g:slime_last_channel) == 1
    unlet g:slime_last_channel
    if exists("b:slime_config")
      unlet b:slime_config
    endif
  else
    let bufinfo = s:get_filter_bufinfo()


    " tests ifusing a version of Neovim that 
    " doesn't automatically close bufers when closed
    " or there is no autocommand that does that
    if len(bufinfo) == len(g:slime_last_channel)
      call filter(bufinfo, {_, val -> val != current_buffer_jobid})
    endif

    call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})

  endif
endfunction
```


These functions use helper functions that should be self-explanatory. `get-filter-bufinfo` gets the info about all currently open buffers and filters to only include info on open terminal buffers.

I update the `slime#targets#neovim#config()` function:

```vim
function! slime#targets#neovim#config() abort

  " unlet current config if its jobid doesn't exist
  if exists("b:slime_config")
    let bufinfo = s:get_filter_bufinfo()
    let current_jobid = get(b:slime_config, "jobid", "-1")
    if index(bufinfo, current_jobid) == -1
      unlet b:slime_config
    endif
  endif


  if !exists("b:slime_config")
    let last_pid = get(get(g:slime_last_channel, -1, {}), 'pid', '')
    let last_job = get(get(g:slime_last_channel, -1, {}), 'jobid', '')
    let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
  endif

  "include option to input pid
  if exists("g:slime_input_pid") && g:slime_input_pid
    let pid_in = input("pid: ", str2nr(jobpid(b:slime_config["jobid"])))
    let id_in = s:translate_pid_to_id(pid_in)
  else
    if exists("g:slime_get_jobid")
      let id_in = g:slime_get_jobid()
    else
      let id_in = input("jobid: ", str2nr(b:slime_config["jobid"]))
      let id_in = str2nr(id_in)
    endif
    let pid_in = s:translate_id_to_pid(id_in)
  endif

  let b:slime_config["jobid"] = id_in
  let b:slime_config["pid"] = pid_in
endfunction
```

Notable is that the user can now configure to input the terminal's PID rather than the Neovim internal job id. This change is documented in the Neovim target `README`.


## Adding Details on vim-style Mappings

When I was learning vim I was looking through and exploring all the different send-to-repl plugins.  This one seemed great, but I wasn't a fan of the `CTRL-c` key chords. I chose vim because I like the operator-motion style of doinag things.  So I tried other send-to-repl plugins before reading the documentation of this one in more depth to see that the vim-style mappings do exist, they're just not advertised in the `README`.

So I made these additions:

---

## Vim-like mappings

To use vim-style mappings:

```vim
"disables mappings from previous usage section
let g:slime_no_mappings = 1

"send visual selection
xmap <leader>s <Plug>SlimeRegionSend

"send based on motion or text object
nmap <leader>s <Plug>SlimeMotionSend

"send line
nmap <leader>ss <Plug>SlimeLineSend
```

Of course these mappings are just examples; you can set them according to your preference.

---

Hopefully this will let new users see these features from the moment they discover this plugin.


## Expanding `neovim` target documentation


Adds documentation of option to use `pid` rather than neovim's internal `jobid`.

In addition to using `&channel` suggests that the user convigure their statusline to show the terminal `pid` and `jobid`. 



## Using `endif` instead of `end`
(i think) `end` works because it is a unique prefix of `endif`. `endif` is preferred and is what is showed in the documentation. There are almost certainly more places in this plugin I could make this change  but only did it in places where I'm interested.


# Closing Thoughts

- I made these changes because I think that the `vim` and `neovim` targets for this plugin deserve special consideration because the user always has them available, no matter the environment they are using vim/neovim in.

- I tested these changes on the current neovim release and the dev branch, v 10.0.0 using a minimal config. These tests are important because with Neovim 10.0.0 terminal buffers are [automatically closed when the terminal closes](https://github.com/neovim/neovim/pull/15440) 

- If you accept these changes, I have another PR ready to go that makes the user experience even better.



