### PR TITLE
Jobpid fun instead of b:terminal_job_[p]id

### DIFF
--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -82,3 +82,5 @@ end
 The details of how to implement this are left to the user.
 
 This is not possible or straightforward to do in pure vimscript due to capitalization rules of functions stored as variables in Vimscript.
+
+ `vim.api.nvim_eval` (see `:h nvim_eval()`) and other Neovim API functions are available to access all or almost all vimscript capabilities from Lua.

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -7,9 +7,6 @@
 let g:slime_target = "neovim"
 ```
 
-
-
-
 #### Manual/Prompted Configuration
 
 When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested.
@@ -19,11 +16,7 @@ To use the terminal's PID as input instead of Neovim's internal job-id of the te
 ```vim
 let g:slime_input_pid=1
 ```
-
 PIDs of processes of potential target terminals are visible to Neovim on Windows as well as MacOS and Linux.
-
-
-
 
 ##### Process Identification
 
@@ -51,7 +44,7 @@ A useful Lua function to return the Job ID of a terminal is:
 
 ```lua
 local function get_chan_jobid()
-	return vim.api.nvim_eval('&channel > 0 ? &channel : ""')
+  return vim.api.nvim_eval('&channel > 0 ? &channel : ""')
 end
 ```
 
@@ -59,26 +52,21 @@ A useful Lua function to return the Job PID of a terminal is:
 
 ```lua
 local function get_chan_jobpid()
-	return vim.api.nvim_eval('&channel > 0 ? jobpid(&channel) : ""')
+  return vim.api.nvim_eval('&channel > 0 ? jobpid(&channel) : ""')
 end
 ```
 
 Those confused by the syntax of the vimscript string passed as an argument to `vim.api.nvim_eval` should consult `:h ternary`.
 
-
-
-
 ### Automatic Configuration
 
 Instead of the prompted job id input method detailed above, you can specify a lua function that will automatically configure vim-slime with a job id:
-
 
 ```lua
 vim.g.slime_get_jobid = function()
   -- some way to select and return jobid
 end
 ```
-
 The details of how to implement this are left to the user.
 
 This is not possible or straightforward to do in pure vimscript due to capitalization rules of functions stored as variables in Vimscript.

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -70,7 +70,7 @@ Those confused by the syntax of the vimscript string passed as an argument to `v
 
 ### Automatic Configuration
 
-Instead of then prompted process input detailed above, you can specify a lua function that will automatically configure slime with a job id:
+Instead of the prompted job id input method detailed above, you can specify a lua function that will automatically configure vim-slime with a job id:
 
 
 ```lua
@@ -81,4 +81,4 @@ end
 
 The details of how to implement this are left to the user.
 
-This is not possible or straightforward to do in pure vimscript due to capitalization rules.
+This is not possible or straightforward to do in pure vimscript due to capitalization rules of functions stored as variables in Vimscript.

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -7,6 +7,11 @@
 let g:slime_target = "neovim"
 ```
 
+
+
+
+#### Manual/Prompted Configuration
+
 When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested.
 
 To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
@@ -15,12 +20,17 @@ To use the terminal's PID as input instead of Neovim's internal job-id of the te
 let g:slime_input_pid=1
 ```
 
-On Windows Neovim assigns a PID as well.
+PIDs of processes of potential target terminals are visible to Neovim on Windows as well as MacOS and Linux.
+
+
+
+
+##### Process Identification
 
 To manually check the right value of `job-id`  (but not `PID`) try:
 
 ```vim
-    echo &channel
+echo &channel
 ```
 
 from the buffer running your terminal.
@@ -28,17 +38,47 @@ from the buffer running your terminal.
 Another way to easily see the `PID` and job ID is to override the status bar of terminals to show the job id and PID.
 
 ```vim
- autocmd TermOpen * setlocal statusline=%{bufname()}%=id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
+autocmd TermOpen * setlocal statusline=%{bufname()}%=id:\ %{&channel}\ pid:\ %{jobpid(&channel)}
 ```
 
 See `h:statusline` in Vim's documentiation for more details.
 
-If you are using a plugin to manage your status line, see that plugin's documentation to see how to confiugre the status line to display `b:terminal_job_id` and `b:terminal_job_pid`.
+If you are using a plugin to manage your status line, see that plugin's documentation to see how to confiugre the status line to display `&channel` and `jobpid(&channel)`.
 
-You can also specify a function to query the jobid as
+Many status line plugins for Neovim are configured in lua.
+
+A useful Lua function to return the Job ID of a terminal is:
+
+```lua
+local function get_chan_jobid()
+	return vim.api.nvim_eval('&channel > 0 ? &channel : ""')
+end
+```
+
+A useful Lua function to return the Job PID of a terminal is:
+
+```lua
+local function get_chan_jobpid()
+	return vim.api.nvim_eval('&channel > 0 ? jobpid(&channel) : ""')
+end
+```
+
+Those confused by the syntax of the vimscript string passed as an argument to `vim.api.nvim_eval` should consult `:h ternary`.
+
+
+
+
+### Automatic Configuration
+
+Instead of then prompted process input detailed above, you can specify a lua function that will automatically configure slime with a job id:
+
 
 ```lua
 vim.g.slime_get_jobid = function()
   -- some way to select and return jobid
 end
 ```
+
+The details of how to implement this are left to the user.
+
+This is not possible or straightforward to do in pure vimscript due to capitalization rules.

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -49,9 +49,9 @@ endfunction
 
 function! slime#targets#neovim#SlimeAddChannel()
   if !exists("g:slime_last_channel")
-    let g:slime_last_channel = [{'jobid': &channel, 'pid': b:terminal_job_pid}]
+    let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
   else
-    call add(g:slime_last_channel, {'jobid': &channel, 'pid': b:terminal_job_pid})
+    call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
   endif
 endfunction
 


### PR DESCRIPTION
In [my previous pull request](https://github.com/jpalardy/vim-slime/pull/411) @jiz4oh commented:

> Hi @jam1015, thanks for your great works, there is a polite reminder, the `b:terminal_job_pid` is deprecated and will be removed in future. Should instead use `jobpid()` as follow the official suggestion <img alt="image" width="656" src="https://private-user-images.githubusercontent.com/41264693/299730147-80793205-575f-4ee1-b2fb-a6c7fa06fefd.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDYyNDU1OTQsIm5iZiI6MTcwNjI0NTI5NCwicGF0aCI6Ii80MTI2NDY5My8yOTk3MzAxNDctODA3OTMyMDUtNTc1Zi00ZWUxLWIyZmItYTZjN2ZhMDZmZWZkLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAxMjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMTI2VDA1MDEzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTY0NWVlMzY5YzdiZWRhZDc4ZGI5Yjg0NzdkOGU0MTE3MDM0YzE1ZDJhZjMxNzlkMDhjMTA2MzAyM2Q0MDBjNTYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.KKlSyTimz35eCrp4XpFb2nUd7LA1wZ8uHbIZ6vPq3iM">

This PR fixes the issues he raised (changes to `autoload/slime/targets/neovim.vim` , and further improves documentation for the Neovim target (changes to `assets/doc/targets/neovim.md`). 