### PR TITLE
Unset invalid slime_config since neovim terminal closed

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -29,7 +29,7 @@ endfunction
 
 function! s:SlimeGetConfig()
   " b:slime_config already configured...
-  if exists("b:slime_config")
+  if exists("b:slime_config") && !empty(b:slime_config)
     return
   endif
   " assume defaults, if they exist

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -58,6 +58,13 @@ endfunction
 function! slime#targets#neovim#SlimeClearChannel()
   let current_buffer_jobid = get(b:,"terminal_job_id",-1)
 
+  let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
+      \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
+
+  for buf in related_bufs
+    call setbufvar(buf['bufnr'], 'slime_config', {})
+  endfor
+    
   if !exists("g:slime_last_channel")
     if exists("b:slime_config")
       unlet b:slime_config

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -11,20 +11,28 @@ function! slime#targets#neovim#config() abort
   endif
 
   if !exists("b:slime_config")
-    let last_pid = get(get(g:slime_last_channel, -1, {}), 'pid', '')
-    let last_job = get(get(g:slime_last_channel, -1, {}), 'jobid', '')
+    let last_pid = get(get(get(g:, 'slime_last_channel', []), -1, {}), 'pid', '')
+    let last_job = get(get(get(g:, 'slime_last_channel', []), -1, {}), 'jobid', '')
     let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
   endif
 
   " include option to input pid
   if exists("g:slime_input_pid") && g:slime_input_pid
-    let pid_in = input("pid: ", str2nr(jobpid(b:slime_config["jobid"])))
+    let default_pid = jobpid(b:slime_config["jobid"])
+    if !empty(default_pid)
+      let default_pid = str2nr(default_pid)
+    end
+    let pid_in = input("pid: ", default_pid)
     let id_in = s:translate_pid_to_id(pid_in)
   else
     if exists("g:slime_get_jobid")
       let id_in = g:slime_get_jobid()
     else
-      let id_in = input("jobid: ", str2nr(b:slime_config["jobid"]))
+      let default_jid = b:slime_config["jobid"]
+      if !empty(default_jid)
+        let default_jid = str2nr(default_jid)
+      end
+      let id_in = input("jobid: ", default_jid)
       let id_in = str2nr(id_in)
     endif
     let pid_in = s:translate_id_to_pid(id_in)


### PR DESCRIPTION
This pr basically is some improvements of https://github.com/jpalardy/vim-slime/pull/411

They are
- Unset invalid slime_config since neovim terminal closed
- Re-require config if b:slime_config is empty due to there is no way to unlet b:slime_config of a specified buffer
- Do not raise `E121 undefined variable` error if there is no opened terminal