### PR TITLE
Validate in target

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To control exactly what is sent, you can manually select text before calling `vi
 
 ## Vim Style Mappings
 
-To send text vim-style mappings, such as `slime operator+motion` or `slime operator+text object` see the appropriate [section of the advanced configuration documentation](assets/doc/advanced.md#vim-style-mappings).
+To send text using vim-style mappings, such as `slime operator+motion` or `slime operator+text object` see the appropriate [section of the advanced configuration documentation](assets/doc/advanced.md#vim-style-mappings).
 
 Config prompt
 --------------

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -9,15 +9,24 @@ let g:slime_target = "neovim"
 
 ## Manual/Prompted Configuration
 
-When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values.
+When you invoke `vim-slime` for the first time, `:SlimeConfig` or one of the send functions, you will be prompted for more configuration.
+
+If the global variable `g:slime_suggest_default` is:
+
+- Nonzero (logical True): The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values.
+
+- `0`: (logical False): No default will be suggested.
+
+
+In either case, in Neovim's default configuration, menu-based completion can be activated with `<Tab>`/`<S-Tab>`, and the menu can be navigated with `<Tab>`/`<S-Tab` or `<C-n>`/`<C-p>`.  Autocompletion plugins such as [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) can interfere with this.
 
 To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
 
 ```vim
 let g:slime_input_pid=1
 ```
-PIDs of processes of potential target terminals are visible to Neovim on Windows as well as MacOS and Linux.
 
+PIDs of processes of potential target terminals are visible to Neovim on Windows as well as MacOS and Linux.
 
 
 ## Menu Prompted Configuration
@@ -83,6 +92,7 @@ autocmd TermOpen * setlocal statusline=%{bufname()}%=id:\ %{&channel}\ pid:\ %{S
 
 See `h:statusline` in Neovim's documentiation for more details.
 
+### Statusline Plugins
 If you are using a plugin to manage your status line, see that plugin's documentation to see how to confiugre the status line to display `&channel` and `jobpid(&channel)`.
 
 Many status line plugins for Neovim are configured in lua.
@@ -114,6 +124,55 @@ end
 ```
 
 Those confused by the syntax of the vimscript string passed as an argument to `vim.api.nvim_eval` should consult `:h ternary`.
+
+## Status-Line Modifications for Configured Buffers
+
+Here is an example snippet of vimscrip to set the status line for buffers that are configured to send code to a terminal:
+
+```vim
+" Function to safely check for b:slime_config and return the jobid
+function! GetSlimeJobId()
+  if exists("b:slime_config") && type(b:slime_config) == v:t_dict && has_key(b:slime_config, 'jobid') && !empty(b:slime_config['jobid'])
+    return ' | jobid: ' . b:slime_config['jobid'] . ' '
+  endif
+  return ''
+endfunction
+
+" Function to safely check for b:slime_config and return the pid
+function! GetSlimePid()
+  if exists("b:slime_config") && type(b:slime_config) == v:t_dict && has_key(b:slime_config, 'pid') && !empty(b:slime_config['pid'])
+    return 'pid: ' . b:slime_config['pid']
+  endif
+  return ''
+endfunction
+
+
+"default statuslin with :set ruler
+set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
+" Append the custom function outputs to the right side of the status line, with " | " as a separator
+```
+
+### Lua Functions For Returning Config Components
+
+```lua
+local function get_slime_jobid()
+  if vim.b.slime_config and vim.b.slime_config.jobid then
+    return vim.b.slime_config.jobid
+  else
+    return ""
+  end
+end
+```
+
+```lua
+local function get_slime_pid()
+  if vim.b.slime_config and vim.b.slime_config.pid then
+    return vim.b.slime_config.pid
+  else
+    return ""
+  end
+end
+```
 
 ## Automatic Configuration
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -1,5 +1,4 @@
-
-### NeoVim :terminal
+# NeoVim :terminal
 
 [NeoVim :terminal](https://neovim.io/doc/user/nvim_terminal_emulator.html) is *not* the default, to use it you will have to add this line to your `.vimrc`:
 
@@ -7,7 +6,8 @@
 let g:slime_target = "neovim"
 ```
 
-#### Manual/Prompted Configuration
+
+## Manual/Prompted Configuration
 
 When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values.
 
@@ -18,7 +18,43 @@ let g:slime_input_pid=1
 ```
 PIDs of processes of potential target terminals are visible to Neovim on Windows as well as MacOS and Linux.
 
-##### Process Identification
+
+
+## List Prompted Configuration
+
+To be prompted with a numbered list of all available terminals which the user can select from by inputting a number, or, if the mouse is enabled, clicking on an entry, set `g:slime_menu_config` to a nonzero value.
+
+```vim
+let g:slime_input_list=1
+```
+
+This takes precedence over `g:slime_input_pid`.
+
+The default order of fields in each terminal description in the menu is 
+
+1. `pid`  The system process identifier of the shell.
+2. `jobid` The Neovim internal job number of the terminal.
+3. `term_title` Usually either the systemname, username, and current directory of the shell, or the name of the currently running process in that shell. (unlabeled by default)
+4. `name` The name of the terminal buffer (unlabeled by default).
+
+The user can reorder these items and set their labels in the menu in the menu by setting a global variable,  `g:slime_neovim_menu_order`, that should be an array of dictionaries. Keys should be exactly the names of the fields, shown above, and the values (which should  be strings) will be the labels in the menu, according to user preference.  Use empty strings for no label.  The dictionaries in the array can be in the user's preferred order.
+
+For example:
+
+```vim
+let g:slime_neovim_menu_order = [{'name': 'buffer name: '}, {'pid': 'shell process identifier: '}, {'jobid': 'neovim internal job identifier: '}, {'term_title': 'process or pwd: '}]
+```
+
+The user can also set the delimeter (including whitespace) string between the fields (`, ` by default) with `g:slime_neovim_menu_delimiter`.
+
+```vim
+let g:slime_neovim_menu_delimiter = ' | '
+```
+
+No validation is performed on these customization values so be sure they are properly set.
+
+
+## Terminal Process Identification
 
 To manually check the right value of `job-id`  (but not `PID`) try:
 
@@ -58,7 +94,7 @@ end
 
 Those confused by the syntax of the vimscript string passed as an argument to `vim.api.nvim_eval` should consult `:h ternary`.
 
-### Automatic Configuration
+## Automatic Configuration
 
 Instead of the prompted job id input method detailed above, you can specify a lua function that will automatically configure vim-slime with a job id:
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -93,6 +93,7 @@ autocmd TermOpen * setlocal statusline=%{bufname()}%=id:\ %{&channel}\ pid:\ %{S
 See `h:statusline` in Neovim's documentiation for more details.
 
 ### Statusline Plugins
+
 If you are using a plugin to manage your status line, see that plugin's documentation to see how to confiugre the status line to display `&channel` and `jobpid(&channel)`.
 
 Many status line plugins for Neovim are configured in lua.
@@ -154,6 +155,7 @@ set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
 
 ### Lua Functions For Returning Config Components
 
+
 ```lua
 local function get_slime_jobid()
   if vim.b.slime_config and vim.b.slime_config.jobid then
@@ -173,6 +175,8 @@ local function get_slime_pid()
   end
 end
 ```
+
+Can be useful for status line plugins.
 
 ## Automatic Configuration
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -25,7 +25,7 @@ PIDs of processes of potential target terminals are visible to Neovim on Windows
 To be prompted with a numbered menu of all available terminals which the user can select from by inputting a number, or, if the mouse is enabled, clicking on an entry, set `g:slime_menu_config` to a nonzero value.
 
 ```vim
-let g:slime_input_list=1
+let g:slime_menu_config=1
 ```
 
 This takes precedence over `g:slime_input_pid`.

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -193,3 +193,26 @@ The details of how to implement this are left to the user.
 This is not possible or straightforward to do in pure vimscript due to capitalization rules of functions stored as variables in Vimscript.
 
  `vim.api.nvim_eval` (see `:h nvim_eval()`) and other Neovim API functions are available to access all or almost all vimscript capabilities from Lua.
+
+ ## Example Installation and Configuration with [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+
+ ```lua
+{
+	"jpalardy/vim-slime",
+	init = function()
+		-- these two should be set before the plugin loads
+		vim.g.slime_target = "neovim"
+		vim.g.slime_no_mappings = true
+	end,
+	config = function()
+		vim.g.slime_input_pid = false
+		vim.g.slime_suggest_default = true
+		vim.g.slime_menu_config = false
+		vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
+		vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })
+		vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true, silent = false })
+		vim.keymap.set("x", "gzc", "<Plug>SlimeConfig", { remap = true, silent = false })
+	end,
+}
+ ```

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -12,14 +12,14 @@ When you invoke `vim-slime` for the first time, `:SlimeConfig` or one of the sen
 
 If the global variable `g:slime_suggest_default` is:
 
-- Nonzero (logical True): The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values.
+- Nonzero (logical True): The last terminal you opened before calling vim-slime will determine which job ID is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values.
 
 - `0`: (logical False): No default will be suggested.
 
 
 In either case, in Neovim's default configuration, menu-based completion can be activated with `<Tab>`/`<S-Tab>`, and the menu can be navigated with `<Tab>`/`<S-Tab` or `<C-n>`/`<C-p>`.  Autocompletion plugins such as [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) can interfere with this.
 
-To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
+To use the terminal's PID as input instead of Neovim's internal job ID of the terminal:
 
 ```vim
 let g:slime_input_pid=1
@@ -66,7 +66,7 @@ No validation is performed on these customization values so be sure they are pro
 
 As menioned earlier, the `PID` of a process is included in the name of a terminal buffer.
 
-To manually check the right value of `job-id`  (but not `PID`) try:
+To manually check the right value of the terminal job ID,  (but not pid) try:
 
 ```vim
 echo &channel
@@ -74,7 +74,7 @@ echo &channel
 
 from the buffer running your terminal.
 
-Another way to easily see the `PID` and job ID is to override the status bar of terminals to show the job id and PID.
+Another way to easily see the `PID` and job ID is to override the status bar of terminals to show the job ID and PID.
 
 ```vim
 " in case an external process kills the terminal's shell and &channel doesn't exist anymore
@@ -132,7 +132,7 @@ Those confused by the syntax of the vimscript string passed as an argument to `v
 Here is an example snippet of vimscript to set the status line for buffers that are configured to send code to a terminal:
 
 ```vim
-" Function to safely check for b:slime_config and return the jobid
+" Function to safely check for b:slime_config and return the job ID
 function! GetSlimeJobId()
   if exists("b:slime_config") && type(b:slime_config) == v:t_dict && has_key(b:slime_config, 'jobid') && !empty(b:slime_config['jobid'])
     return ' | jobid: ' . b:slime_config['jobid'] . ' '
@@ -181,11 +181,11 @@ Can be useful for status line plugins.
 
 ## Automatic Configuration
 
-Instead of the prompted job id input method detailed above, you can specify a lua function that will automatically configure vim-slime with a job id:
+Instead of the prompted job ID input method detailed above, you can specify a lua function that will automatically configure vim-slime with a job id:
 
 ```lua
 vim.g.slime_get_jobid = function()
-  -- some way to select and return jobid
+  -- some way to select and return job ID
 end
 ```
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -14,7 +14,8 @@ If the global variable `g:slime_suggest_default` is:
 
 - Nonzero (logical True): The last terminal you opened before calling vim-slime will determine which job ID is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values.
 
-- `0`: (logical False): No default will be suggested.
+- `0` (logical False), or nonexistent: No default will be suggested.
+
 
 
 In either case, in Neovim's default configuration, menu-based completion can be activated with `<Tab>`/`<S-Tab>`, and the menu can be navigated with `<Tab>`/`<S-Tab` or `<C-n>`/`<C-p>`.  Autocompletion plugins such as [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) can interfere with this.
@@ -157,6 +158,8 @@ set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
 ### Lua Functions For Returning Config Components
 
 
+Can be useful for status line plugins:
+
 ```lua
 local function get_slime_jobid()
   if vim.b.slime_config and vim.b.slime_config.jobid then
@@ -177,7 +180,6 @@ local function get_slime_pid()
 end
 ```
 
-Can be useful for status line plugins.
 
 ## Automatic Configuration
 
@@ -198,23 +200,23 @@ This is not possible or straightforward to do in pure vimscript due to capitaliz
  ## Example Installation and Configuration with [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 
- ```lua
+```lua
 {
-	"jpalardy/vim-slime",
-	init = function()
-		-- these two should be set before the plugin loads
-		vim.g.slime_target = "neovim"
-		vim.g.slime_no_mappings = true
-	end,
-	config = function()
-		vim.g.slime_input_pid = false
-		vim.g.slime_suggest_default = true
-		vim.g.slime_menu_config = false
-		-- called MotionSend but works with textobjects as well
-		vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
-		vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })
-		vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true, silent = false })
-		vim.keymap.set("n", "gzc", "<Plug>SlimeConfig", { remap = true, silent = false })
-	end,
+  "jpalardy/vim-slime",
+  init = function()
+    -- these two should be set before the plugin loads
+    vim.g.slime_target = "neovim"
+    vim.g.slime_no_mappings = true
+  end,
+  config = function()
+    vim.g.slime_input_pid = false
+    vim.g.slime_suggest_default = true
+    vim.g.slime_menu_config = false
+    -- called MotionSend but works with textobjects as well
+    vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
+    vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })
+    vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true, silent = false })
+    vim.keymap.set("n", "gzc", "<Plug>SlimeConfig", { remap = true, silent = false })
+  end,
 }
- ```
+```

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -25,7 +25,7 @@ To use the terminal's PID as input instead of Neovim's internal job-id of the te
 let g:slime_input_pid=1
 ```
 
-PIDs of processes of potential target terminals are visible to Neovim on Windows as well as MacOS and Linux.
+The `PID` is included in the terminal buffers's name, visible in the default terminal window status bar.
 
 
 ## Menu Prompted Configuration
@@ -63,6 +63,8 @@ No validation is performed on these customization values so be sure they are pro
 
 
 ## Terminal Process Identification
+
+As menioned earlier, the `PID` of a process is included in the name of a terminal buffer.
 
 To manually check the right value of `job-id`  (but not `PID`) try:
 
@@ -127,7 +129,7 @@ Those confused by the syntax of the vimscript string passed as an argument to `v
 
 ## Status-Line Modifications for Configured Buffers
 
-Here is an example snippet of vimscrip to set the status line for buffers that are configured to send code to a terminal:
+Here is an example snippet of vimscript` to set the status line for buffers that are configured to send code to a terminal:
 
 ```vim
 " Function to safely check for b:slime_config and return the jobid

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -67,7 +67,17 @@ from the buffer running your terminal.
 Another way to easily see the `PID` and job ID is to override the status bar of terminals to show the job id and PID.
 
 ```vim
-autocmd TermOpen * setlocal statusline=%{bufname()}%=id:\ %{&channel}\ pid:\ %{jobpid(&channel)}
+" in case an external process kills the terminal's shell and &channel doesn't exist anymore
+function Safe_jobpid(channel_in)
+  let pid_out = ""
+  try
+    let pid_out = string(jobpid(a:channel_in))
+  catch /^Vim\%((\a\+)\)\=:E900/
+  endtry
+  return pid_out
+endfunction
+
+autocmd TermOpen * setlocal statusline=%{bufname()}%=id:\ %{&channel}\ pid:\ %{Safe_jobpid(&channel)}
 ```
 
 See `h:statusline` in Neovim's documentiation for more details.

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -9,7 +9,7 @@ let g:slime_target = "neovim"
 
 #### Manual/Prompted Configuration
 
-When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested.
+When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values.
 
 To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
 
@@ -34,7 +34,7 @@ Another way to easily see the `PID` and job ID is to override the status bar of 
 autocmd TermOpen * setlocal statusline=%{bufname()}%=id:\ %{&channel}\ pid:\ %{jobpid(&channel)}
 ```
 
-See `h:statusline` in NeoVim's documentiation for more details.
+See `h:statusline` in Neovim's documentiation for more details.
 
 If you are using a plugin to manage your status line, see that plugin's documentation to see how to confiugre the status line to display `&channel` and `jobpid(&channel)`.
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -20,9 +20,9 @@ PIDs of processes of potential target terminals are visible to Neovim on Windows
 
 
 
-## List Prompted Configuration
+## Menu Prompted Configuration
 
-To be prompted with a numbered list of all available terminals which the user can select from by inputting a number, or, if the mouse is enabled, clicking on an entry, set `g:slime_menu_config` to a nonzero value.
+To be prompted with a numbered menu of all available terminals which the user can select from by inputting a number, or, if the mouse is enabled, clicking on an entry, set `g:slime_menu_config` to a nonzero value.
 
 ```vim
 let g:slime_input_list=1
@@ -68,8 +68,9 @@ Another way to easily see the `PID` and job ID is to override the status bar of 
 
 ```vim
 " in case an external process kills the terminal's shell and &channel doesn't exist anymore
-function Safe_jobpid(channel_in)
+function! Safe_jobpid(channel_in)
   let pid_out = ""
+  " in case an external process kills the terminal's shell; jobpid will error
   try
     let pid_out = string(jobpid(a:channel_in))
   catch /^Vim\%((\a\+)\)\=:E900/
@@ -98,7 +99,17 @@ A useful Lua function to return the Job PID of a terminal is:
 
 ```lua
 local function get_chan_jobpid()
-  return vim.api.nvim_eval('&channel > 0 ? jobpid(&channel) : ""')
+  local out = vim.api.nvim_exec2([[
+  let pid_out = ""
+  
+  try
+  let pid_out = string(jobpid(&channel))
+  " in case an external process kills the terminal's shell; jobpid will error
+  catch /^Vim\%((\a\+)\)\=:E900/
+  endtry
+  		echo pid_out
+  ]], {output = true})
+  return out["output"] --returns as string
 end
 ```
 
@@ -113,6 +124,7 @@ vim.g.slime_get_jobid = function()
   -- some way to select and return jobid
 end
 ```
+
 The details of how to implement this are left to the user.
 
 This is not possible or straightforward to do in pure vimscript due to capitalization rules of functions stored as variables in Vimscript.

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -115,9 +115,9 @@ local function get_chan_jobpid()
   let pid_out = ""
   
   try
-  let pid_out = string(jobpid(&channel))
-  " in case an external process kills the terminal's shell; jobpid will error
-  catch /^Vim\%((\a\+)\)\=:E900/
+    let pid_out = string(jobpid(&channel))
+    " in case an external process kills the terminal's shell; jobpid will error
+    catch /^Vim\%((\a\+)\)\=:E900/
   endtry
   		echo pid_out
   ]], {output = true})
@@ -129,7 +129,7 @@ Those confused by the syntax of the vimscript string passed as an argument to `v
 
 ## Status-Line Modifications for Configured Buffers
 
-Here is an example snippet of vimscript` to set the status line for buffers that are configured to send code to a terminal:
+Here is an example snippet of vimscript to set the status line for buffers that are configured to send code to a terminal:
 
 ```vim
 " Function to safely check for b:slime_config and return the jobid

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -6,10 +6,9 @@
 let g:slime_target = "neovim"
 ```
 
+When you invoke `vim-slime` for the first time, `:SlimeConfig` or one of the send functions, you will be prompted for more configuration.
 
 ## Manual/Prompted Configuration
-
-When you invoke `vim-slime` for the first time, `:SlimeConfig` or one of the send functions, you will be prompted for more configuration.
 
 If the global variable `g:slime_suggest_default` is:
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -209,10 +209,11 @@ This is not possible or straightforward to do in pure vimscript due to capitaliz
 		vim.g.slime_input_pid = false
 		vim.g.slime_suggest_default = true
 		vim.g.slime_menu_config = false
+		-- called MotionSend but works with textobjects as well
 		vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
 		vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })
 		vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true, silent = false })
-		vim.keymap.set("x", "gzc", "<Plug>SlimeConfig", { remap = true, silent = false })
+		vim.keymap.set("n", "gzc", "<Plug>SlimeConfig", { remap = true, silent = false })
 	end,
 }
  ```

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -213,13 +213,14 @@ function! s:SlimeDispatchValidate(name, ...)
 
   let fun_string = "slime#targets#" . slime#config#resolve("target") . "#" . a:name
   " using try catch because exists() doesn't detect autoload functions that aren't yet loaded
+  " the idea is to return the interger 1 for true in cases where a target doesn't have
+  " the called validation function implemented
   try
     return call(fun_string, a:000)
   catch /^Vim\%((\a\+)\)\=:E117:/
     return 1
   endtry
 
-  "1 means true
 endfunction
 
 " delegation

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -27,7 +27,7 @@ function! s:_EscapeText(text)
   endif
 endfunction
 
-function! slime#GetConfig()
+function! s:SlimeGetConfig()
   " b:slime_config already configured...
   if exists("b:slime_config") && !empty(b:slime_config)
     return
@@ -45,6 +45,7 @@ function! slime#GetConfig()
 endfunction
 
 function! slime#send_op(type, ...) abort
+  call s:SlimeGetConfig()
 
   let sel_save = &selection
   let &selection = "inclusive"
@@ -71,6 +72,7 @@ function! slime#send_op(type, ...) abort
 endfunction
 
 function! slime#send_range(startline, endline) abort
+  call s:SlimeGetConfig()
 
   let rv = getreg('"')
   let rt = getregtype('"')
@@ -80,6 +82,7 @@ function! slime#send_range(startline, endline) abort
 endfunction
 
 function! slime#send_lines(count) abort
+  call s:SlimeGetConfig()
 
   let rv = getreg('"')
   let rt = getregtype('"')
@@ -125,12 +128,11 @@ endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 function! slime#send(text)
-  call slime#GetConfig()
+  call s:SlimeGetConfig()
 
   " this used to return a string, but some receivers (coffee-script)
   " will flush the rest of the buffer given a special sequence (ctrl-v)
   " so we, possibly, send many strings -- but probably just one
-
   let pieces = s:_EscapeText(a:text)
   for piece in pieces
     if type(piece) == 0  " a number
@@ -158,4 +160,3 @@ function! s:SlimeDispatch(name, ...)
   endif
   return call("slime#targets#" . slime#config#resolve("target") . "#" . a:name, a:000)
 endfunction
-

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -29,19 +29,17 @@ endfunction
 
 function! s:SlimeGetConfig()
   " b:slime_config already configured...
-  if exists("b:slime_config")
-    if s:SlimeDispatchValidate("ValidConfig", b:slime_config)
-      return
-    endif
+  if s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
+    return
   endif
   " assume defaults, if they exist
 
   if exists("g:slime_default_config")
     let b:slime_config = g:slime_default_config
-    if !s:SlimeDispatchValidate("ValidConfig", b:slime_config)
-      unlet b:slime_config
-    elseif exists("g:slime_dont_ask_default") && g:slime_dont_ask_default
-      return
+    if !s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
+      if exists("b:slime_config")
+        unlet b:slime_config
+      endif
     endif
   endif
 
@@ -53,10 +51,12 @@ function! s:SlimeGetConfig()
   " prompt user
   call s:SlimeDispatch('config')
 
-  if s:SlimeDispatchValidate("ValidConfig", b:slime_config)
+  if s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
     return
   else
-    unlet b:slime_config
+    if exists("b:slime_config")
+      unlet b:slime_config
+    endif
     throw "invalid config"
   endif
 
@@ -65,45 +65,45 @@ endfunction
 
 
 function! slime#send_op(type, ...) abort
-    let sel_save = &selection
-    let &selection = "inclusive"
-    let rv = getreg('"')
-    let rt = getregtype('"')
+  let sel_save = &selection
+  let &selection = "inclusive"
+  let rv = getreg('"')
+  let rt = getregtype('"')
 
-    if a:0  " Invoked from Visual mode, use '< and '> marks.
-      silent exe "normal! `<" . a:type . '`>y'
-    elseif a:type == 'line'
-      silent exe "normal! '[V']y"
-    elseif a:type == 'block'
-      silent exe "normal! `[\<C-V>`]\y"
-    else
-      silent exe "normal! `[v`]y"
-    endif
+  if a:0  " Invoked from Visual mode, use '< and '> marks.
+    silent exe "normal! `<" . a:type . '`>y'
+  elseif a:type == 'line'
+    silent exe "normal! '[V']y"
+  elseif a:type == 'block'
+    silent exe "normal! `[\<C-V>`]\y"
+  else
+    silent exe "normal! `[v`]y"
+  endif
 
-    call setreg('"', @", 'V')
-    call slime#send(@")
+  call setreg('"', @", 'V')
+  call slime#send(@")
 
-    let &selection = sel_save
-    call setreg('"', rv, rt)
+  let &selection = sel_save
+  call setreg('"', rv, rt)
 
-    call s:SlimeRestoreCurPos()
+  call s:SlimeRestoreCurPos()
 endfunction
 
 function! slime#send_range(startline, endline) abort
 
-    let rv = getreg('"')
-    let rt = getregtype('"')
-    silent exe a:startline . ',' . a:endline . 'yank'
-    call slime#send(@")
-    call setreg('"', rv, rt)
+  let rv = getreg('"')
+  let rt = getregtype('"')
+  silent exe a:startline . ',' . a:endline . 'yank'
+  call slime#send(@")
+  call setreg('"', rv, rt)
 endfunction
 
 function! slime#send_lines(count) abort
-    let rv = getreg('"')
-    let rt = getregtype('"')
-    silent exe 'normal! ' . a:count . 'yy'
-    call slime#send(@")
-    call setreg('"', rv, rt)
+  let rv = getreg('"')
+  let rt = getregtype('"')
+  silent exe 'normal! ' . a:count . 'yy'
+  call slime#send(@")
+  call setreg('"', rv, rt)
 endfunction
 
 function! slime#send_cell() abort
@@ -173,8 +173,10 @@ function! slime#config() abort
   if s:SlimeDispatchValidate("ValidEnv")
     call s:SlimeDispatch('config')
 
-    if !s:SlimeDispatchValidate("ValidConfig", b:slime_config)
-      unlet b:slime_config
+    if !s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
+      if exists("b:slime_config")
+        unlet b:slime_config
+      endif
     endif
   endif
   call inputrestore()

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -35,19 +35,21 @@ function! s:SlimeGetConfig()
     endif
   endif
   " assume defaults, if they exist
+
   if exists("g:slime_default_config")
     let b:slime_config = g:slime_default_config
-
-    " skip confirmation, if configured
-    if exists("g:slime_dont_ask_default") && g:slime_dont_ask_default
-      return
-    endif
-
     if !s:SlimeDispatchValidate("ValidConfig", b:slime_config)
       unlet b:slime_config
+    elseif exists("g:slime_dont_ask_default") && g:slime_dont_ask_default
+      return
     endif
-
   endif
+
+  " skip confirmation, if configured
+  if exists("g:slime_dont_ask_default") && g:slime_dont_ask_default
+    return
+  endif
+
   " prompt user
   call s:SlimeDispatch('config')
 

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -235,7 +235,7 @@ function! s:SlimeDispatchValidate(name, ...)
   endif
 
   let fun_string = "slime#targets#" . slime#config#resolve("target") . "#" . a:name
-  " usint try catcht because exists() doesn't detect autoload functions that aren't yet loaded
+  " using try catch because exists() doesn't detect autoload functions that aren't yet loaded
   try
     return call(fun_string, a:000)
   catch /^Vim\%((\a\+)\)\=:E117:/

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -151,7 +151,6 @@ function! slime#send(text)
       return
     endtry
 
-     colorscheme delek
     " this used to return a string, but some receivers (coffee-script)
     " will flush the rest of the buffer given a special sequence (ctrl-v)
     " so we, possibly, send many strings -- but probably just one

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -3,31 +3,6 @@
 " Helpers
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-" takes any number of strings as arguments: if one of those strings exists
-" as an environment variable in vim, return its value, if none of them exist
-" return v:null
-function! s:resolve(...)
-  for name in a:000
-    if exists(name)
-      return eval(name)
-    endif
-  endfor
-  return v:null
-endfunction
-
-" takes any number of strings as arguments: if one of those strings exists
-" as an environment variable in vim, return its value, if none of them exist
-" return 'default' arg
-function! s:resolve_default(default, ...)
-  for name in a:000
-    if exists(name)
-      return eval(name)
-    endif
-  endfor
-  " 0 means false
-  return a:default
-endfunction
-
 function! s:_EscapeText(text)
   let escape_text_fn = "_EscapeText_" . substitute(&filetype, "[.]", "_", "g")
   if exists("&filetype")

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -189,7 +189,7 @@ function! s:SlimeDispatchValidate(name, ...)
   let fun_string = "slime#targets#" . slime#config#resolve("target") . "#" . a:name
   " using try catch because exists() doesn't detect autoload functions that aren't yet loaded
   " the idea is to return the interger 1 for true in cases where a target doesn't have
-  " the called validation function implemented
+  " the called validation function implemented. E117 is 'Unknown function'.
   try
     return call(fun_string, a:000)
   catch /^Vim\%((\a\+)\)\=:E117:/

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -235,12 +235,14 @@ function! s:SlimeDispatchValidate(name, ...)
   endif
 
   let fun_string = "slime#targets#" . slime#config#resolve("target") . "#" . a:name
-  if exists("*" . fun_string)
+  " usint try catcht because exists() doesn't detect autoload functions that aren't yet loaded
+  try
     return call(fun_string, a:000)
-  endif
+  catch /^Vim\%((\a\+)\)\=:E117:/
+    return 1
+  endtry
 
   "1 means true
-  return 1
 endfunction
 
 " delegation

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -27,44 +27,25 @@ function! s:_EscapeText(text)
   endif
 endfunction
 
-function! s:SlimeGetConfig()
+function! slime#GetConfig()
   " b:slime_config already configured...
-  if exists("b:slime_config") && s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
+  if exists("b:slime_config") && !empty(b:slime_config)
     return
   endif
   " assume defaults, if they exist
-
   if exists("g:slime_default_config")
     let b:slime_config = g:slime_default_config
-    if !s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
-      if exists("b:slime_config")
-        unlet b:slime_config
-      endif
-    endif
   endif
-
   " skip confirmation, if configured
   if exists("g:slime_dont_ask_default") && g:slime_dont_ask_default
     return
   endif
-
   " prompt user
   call s:SlimeDispatch('config')
-
-  if s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
-    return
-  else
-    if exists("b:slime_config")
-      unlet b:slime_config
-    endif
-    throw "invalid config"
-  endif
-
 endfunction
 
-
-
 function! slime#send_op(type, ...) abort
+
   let sel_save = &selection
   let &selection = "inclusive"
   let rv = getreg('"')
@@ -99,6 +80,7 @@ function! slime#send_range(startline, endline) abort
 endfunction
 
 function! slime#send_lines(count) abort
+
   let rv = getreg('"')
   let rt = getregtype('"')
   silent exe 'normal! ' . a:count . 'yy'
@@ -143,63 +125,27 @@ endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 function! slime#send(text)
+  call slime#GetConfig()
 
-  if s:SlimeDispatchValidate("ValidEnv")
-    try
-      call s:SlimeGetConfig()
-    catch \invalid config\
-      return
-    endtry
-
-    " this used to return a string, but some receivers (coffee-script)
-    " will flush the rest of the buffer given a special sequence (ctrl-v)
-    " so we, possibly, send many strings -- but probably just one
-    let pieces = s:_EscapeText(a:text)
-    for piece in pieces
-      if type(piece) == 0  " a number
-        if piece > 0  " sleep accepts only positive count
-          execute 'sleep' piece . 'm'
-        endif
-      else
-        call s:SlimeDispatch('send', b:slime_config, piece)
+  " this used to return a string, but some receivers (coffee-script)
+  " will flush the rest of the buffer given a special sequence (ctrl-v)
+  " so we, possibly, send many strings -- but probably just one
+  let pieces = s:_EscapeText(a:text)
+  for piece in pieces
+    if type(piece) == 0  " a number
+      if piece > 0  " sleep accepts only positive count
+        execute 'sleep' piece . 'm'
       endif
-    endfor
-  endif
+    else
+      call s:SlimeDispatch('send', b:slime_config, piece)
+    endif
+  endfor
 endfunction
-
 
 function! slime#config() abort
   call inputsave()
-  if s:SlimeDispatchValidate("ValidEnv")
-    call s:SlimeDispatch('config')
-
-    if !s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
-      if exists("b:slime_config")
-        unlet b:slime_config
-      endif
-    endif
-  endif
+  call s:SlimeDispatch('config')
   call inputrestore()
-endfunction
-
-" delegation
-function! s:SlimeDispatchValidate(name, ...)
-  " allow custom override
-  let override_fn = "SlimeOverride" . slime#common#capitalize(a:name)
-  if exists("*" . override_fn)
-    return call(override_fn, a:000)
-  endif
-
-  let fun_string = "slime#targets#" . slime#config#resolve("target") . "#" . a:name
-  " using try catch because exists() doesn't detect autoload functions that aren't yet loaded
-  " the idea is to return the interger 1 for true in cases where a target doesn't have
-  " the called validation function implemented. E117 is 'Unknown function'.
-  try
-    return call(fun_string, a:000)
-  catch /^Vim\%((\a\+)\)\=:E117:/
-    return 1
-  endtry
-
 endfunction
 
 " delegation
@@ -211,3 +157,4 @@ function! s:SlimeDispatch(name, ...)
   endif
   return call("slime#targets#" . slime#config#resolve("target") . "#" . a:name, a:000)
 endfunction
+

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -45,8 +45,6 @@ function! s:SlimeGetConfig()
 endfunction
 
 function! slime#send_op(type, ...) abort
-  call s:SlimeGetConfig()
-
   let sel_save = &selection
   let &selection = "inclusive"
   let rv = getreg('"')
@@ -72,8 +70,6 @@ function! slime#send_op(type, ...) abort
 endfunction
 
 function! slime#send_range(startline, endline) abort
-  call s:SlimeGetConfig()
-
   let rv = getreg('"')
   let rt = getregtype('"')
   silent exe a:startline . ',' . a:endline . 'yank'
@@ -82,8 +78,6 @@ function! slime#send_range(startline, endline) abort
 endfunction
 
 function! slime#send_lines(count) abort
-  call s:SlimeGetConfig()
-
   let rv = getreg('"')
   let rt = getregtype('"')
   silent exe 'normal! ' . a:count . 'yy'

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -29,7 +29,7 @@ endfunction
 
 function! s:SlimeGetConfig()
   " b:slime_config already configured...
-  if s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
+  if exists("b:slime_config") && s:SlimeDispatchValidate("ValidConfig", "b:slime_config")
     return
   endif
   " assume defaults, if they exist
@@ -151,6 +151,7 @@ function! slime#send(text)
       return
     endtry
 
+     colorscheme delek
     " this used to return a string, but some receivers (coffee-script)
     " will flush the rest of the buffer given a special sequence (ctrl-v)
     " so we, possibly, send many strings -- but probably just one

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -88,13 +88,6 @@ endfunction
 
 
 function! slime#send_op(type, ...) abort
-  if s:SlimeDispatchValidate("ValidEnv")
-    try
-      call s:SlimeGetConfig()
-    catch \invalid config\
-      return
-    endtry
-
     let sel_save = &selection
     let &selection = "inclusive"
     let rv = getreg('"')
@@ -117,39 +110,23 @@ function! slime#send_op(type, ...) abort
     call setreg('"', rv, rt)
 
     call s:SlimeRestoreCurPos()
-  endif
 endfunction
 
 function! slime#send_range(startline, endline) abort
-  if s:SlimeDispatchValidate("ValidEnv")
-    try
-      call s:SlimeGetConfig()
-    catch \invalid config\
-      return
-    endtry
 
     let rv = getreg('"')
     let rt = getregtype('"')
     silent exe a:startline . ',' . a:endline . 'yank'
     call slime#send(@")
     call setreg('"', rv, rt)
-  endif
 endfunction
 
 function! slime#send_lines(count) abort
-  if s:SlimeDispatchValidate("ValidEnv")
-    try
-      call s:SlimeGetConfig()
-    catch \invalid config\
-      return
-    endtry
-
     let rv = getreg('"')
     let rt = getregtype('"')
     silent exe 'normal! ' . a:count . 'yy'
     call slime#send(@")
     call setreg('"', rv, rt)
-  endif
 endfunction
 
 function! slime#send_cell() abort

--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -130,6 +130,7 @@ function! slime#send(text)
   " this used to return a string, but some receivers (coffee-script)
   " will flush the rest of the buffer given a special sequence (ctrl-v)
   " so we, possibly, send many strings -- but probably just one
+
   let pieces = s:_EscapeText(a:text)
   for piece in pieces
     if type(piece) == 0  " a number

--- a/autoload/slime/config.vim
+++ b/autoload/slime/config.vim
@@ -23,3 +23,30 @@ function! slime#config#resolve(config_name)
   echoerr "missing config value for: slime_" . a:config_name
   return v:null
 endfunction
+
+
+
+if slime#config#resolve("target") == "neovim"
+  if has('nvim')
+    " if true use a prompted menu config to 
+    let g:slime_config_defaults["menu_config"] = 0
+
+    " whether to populate the command line with an identifier when configuring
+    let g:slime_config_defaults["suggest_default"] = 1
+
+    "input PID rather than job ID on the command line when configuring
+    let g:slime_config_defaults["input_pid"] = 0
+
+    " can be set to a user-defined function to automatically get a job id. Set as zero here to evaluate to false.
+    let g:slime_config_defaults["get_jobid"] = 0
+
+
+    "order of menu if configuring that way
+    let g:slime_config_defaults["neovim_menu_order"] = [{'pid': 'pid: '}, {'jobid': 'jobid: '}, {'term_title':''}, {'name': ''}]
+
+    "delimiter of menu
+    let g:slime_config_defaults["neovim_menu_delimiter"] = ','
+  else
+    call slime#targets#neovim#EchoWarningMsg("Trying to use Neovim target in standard Vim. This won't work.")
+  endif
+endif

--- a/autoload/slime/config.vim
+++ b/autoload/slime/config.vim
@@ -24,11 +24,8 @@ function! slime#config#resolve(config_name)
   return v:null
 endfunction
 
-
-
 if slime#config#resolve("target") == "neovim"
   if has('nvim')
-    " if true use a prompted menu config to 
     let g:slime_config_defaults["menu_config"] = 0
 
     " whether to populate the command line with an identifier when configuring
@@ -37,15 +34,15 @@ if slime#config#resolve("target") == "neovim"
     "input PID rather than job ID on the command line when configuring
     let g:slime_config_defaults["input_pid"] = 0
 
-    " can be set to a user-defined function to automatically get a job id. Set as zero here to evaluate to false.
+    " can be set to a user-defined function to automatically get a job ID. Set as zero here to evaluate to false.
     let g:slime_config_defaults["get_jobid"] = 0
-
 
     "order of menu if configuring that way
     let g:slime_config_defaults["neovim_menu_order"] = [{'pid': 'pid: '}, {'jobid': 'jobid: '}, {'term_title':''}, {'name': ''}]
 
-    "delimiter of menu
-    let g:slime_config_defaults["neovim_menu_delimiter"] = ','
+    "delimiter of menu if configuring that way
+    let g:slime_config_defaults["neovim_menu_delimiter"] = ', '
+
   else
     call slime#targets#neovim#EchoWarningMsg("Trying to use Neovim target in standard Vim. This won't work.")
   endif

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -19,7 +19,7 @@ function! slime#targets#neovim#config() abort
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
       end
-      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_jobpid_string')
+      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_pid_string')
 
       let jobid_in = s:translate_pid_to_id(pid_in)
     else
@@ -176,7 +176,7 @@ function! slime#targets#neovim#config() abort
   endfunction
 
   " Transforms a channel dictionary with job ida and pid into an array of job IDs.
-  function! s:last_channel_to_jobpid_string(channel_dict)
+  function! s:last_channel_to_pid_string(channel_dict)
     "they will be transformed into pids so caling them by theier final identity
     let job_pids = map(copy(a:channel_dict), {_, val -> val["jobid"]})
      map(job_pids, {_, val -> s:translate_id_to_pid(val)})

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -72,10 +72,14 @@ endfunction
 
 function! slime#targets#neovim#SlimeClearChannel(buf_in) abort
   if !exists("g:slime_last_channel")
+    call s:clear_all_buffs()
     return
   elseif len(g:slime_last_channel) <= 1
+    call s:clear_all_buffs()
     unlet g:slime_last_channel
   else
+    let jobid_to_clear = filter(copy(g:slime_last_channel), {_, val -> val['bufnr'] == a:buf_in})[0]['jobid']
+    call s:clear_related_bufs(jobid_to_clear)
     call filter(g:slime_last_channel, {_, val -> val['bufnr'] != a:buf_in})
   endif
 endfunction
@@ -132,7 +136,7 @@ function! slime#targets#neovim#ValidConfig(config) abort
           \map(copy(g:slime_last_channel), {_, val -> val["jobid"]}),
           \config_in['jobid']) >= 0
           \)
-      echo "Invalid job ID."
+      echo "Job ID not found."
       return 0
     endif
 
@@ -183,6 +187,25 @@ function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos) abort
   return reverse(jobpids) "making most recent the first selected
 endfunction
 
+
+" clears all buffers with a certain invalid configuration
+function! s:clear_related_bufs(id_in) abort
+  let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
+        \ && get(val['variables']['slime_config'], 'jobid', -2) == a:id_in})
+
+  for buf in related_bufs
+    call setbufvar(buf['bufnr'], 'slime_config', {})
+  endfor
+endfunction
+
+" clears all buffers with a certain invalid configuration
+function! s:clear_all_buffs() abort
+  let target_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config") })
+
+  for buf in target_bufs
+    call setbufvar(buf['bufnr'], 'slime_config', {})
+  endfor
+endfunction
 
 function! s:extend_term_buffer_titles(specific_term_info, all_bufinfo) abort
   " add buffer name and terminal title to a dictionary that already has jobid, pid, buffer number

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -19,7 +19,7 @@ function! slime#targets#neovim#config() abort
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
       end
-      let pid_in = input("pid: ", default_pid)
+      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid)
 
       let id_in = s:translate_pid_to_id(pid_in)
     else
@@ -30,7 +30,7 @@ function! slime#targets#neovim#config() abort
         if !empty(default_jobid)
           let default_jobid = str2nr(default_jobid)
         endif
-        let id_in = input("jobid: ", default_jobid)
+        let id_in = input("Configuring vim-slime. Input jobid: ", default_jobid)
         let id_in = str2nr(id_in)
       endif
       let pid_in = s:translate_id_to_pid(id_in)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -16,7 +16,7 @@ function! slime#targets#neovim#config() abort
       let slime_suggest_default = 0
     endif
 
-    " unlet current config if its jobid doesn't exist
+    " unlet current config if its job ID doesn't exist
     if !config_set
       let last_channels = get(g:, 'slime_last_channel', [])
       let most_recent_channel = get(last_channels, -1, {})
@@ -182,7 +182,7 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
   " Ensure the correct keys exist within the configuration
   if !(has_key(a:config, 'jobid'))
     if !a:silent
-      echo "Configration object lacks 'jobid'."
+      echo "Config object lacks 'jobid'."
     endif
     echohl none
     return 0
@@ -190,7 +190,7 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
 
   if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
     if !a:silent
-      echo "No matching job id for the provided pid."
+      echo "No matching job ID for the provided pid."
     endif
     echohl none
     return 0
@@ -201,7 +201,7 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
         \a:config['jobid']) >= 0
         \)
     if !a:silent
-      echo "Invalid Job ID."
+      echo "Invalid job ID."
     endif
     echohl none
     return 0
@@ -209,7 +209,7 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
 
   if s:translate_id_to_pid(a:config['jobid']) == -1
     if !a:silent
-      echo "Job ID not linked to a PID."
+      echo "job ID not linked to a PID."
     endif
     echohl none
     return 0
@@ -238,7 +238,7 @@ function! s:translate_id_to_pid(id) abort
   return pid_out
 endfunction
 
-" Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
+" Transforms a channel dictionary with job ID and pid into an newline separated string  of job IDs.
 " for the purposes of input completion
 function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos) abort
   let jobids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
@@ -246,7 +246,7 @@ function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos) abort
   return reverse(jobids) " making correct order in menu
 endfunction
 
-" Transforms a channel dictionary with job ida and pid into an newline separated string  of job PIDs.
+" Transforms a channel dictionary with job ID and pid into an newline separated string  of job PIDs.
 " for the purposes of input completion
 function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos) abort
   "they will be transformed into pids so naming them by their final identity

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -19,205 +19,205 @@ function! slime#targets#neovim#config() abort
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
     endif
-      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_pid_string')
+    let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_pid_string')
 
-      let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
+    let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
+  else
+    if exists("g:slime_get_jobid")
+      let jobid_in = g:slime_get_jobid()
     else
-      if exists("g:slime_get_jobid")
-        let jobid_in = g:slime_get_jobid()
-      else
-        let default_jobid = b:slime_config["jobid"]
-        if !empty(default_jobid)
-          let default_jobid = str2nr(default_jobid)
-        endif
-        let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'custom,s:last_channel_to_jobid_string')
-        let jobid_in = str2nr(jobid_in)
+      let default_jobid = b:slime_config["jobid"]
+      if !empty(default_jobid)
+        let default_jobid = str2nr(default_jobid)
       endif
-      let pid_in = s:translate_id_to_pid(jobid_in)
+      let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'custom,s:last_channel_to_jobid_string')
+      let jobid_in = str2nr(jobid_in)
     endif
+    let pid_in = s:translate_id_to_pid(jobid_in)
+  endif
 
-    let b:slime_config["jobid"] = jobid_in
-    let b:slime_config["pid"] = pid_in
-  endfunction
+  let b:slime_config["jobid"] = jobid_in
+  let b:slime_config["pid"] = pid_in
+endfunction
 
-  function! slime#targets#neovim#send(config, text)
-    " Neovim jobsend is fully asynchronous, it causes some problems with
-    " iPython %cpaste (input buffering: not all lines sent over)
-    " So this `write_paste_file` can help as a small lock & delay
-    call slime#common#write_paste_file(a:text)
-    call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
-    " if b:slime_config is {"jobid": ""} and not configured
-    " then unset it for automatic configuration next time
-    if b:slime_config["jobid"]  == ""
+function! slime#targets#neovim#send(config, text)
+  " Neovim jobsend is fully asynchronous, it causes some problems with
+  " iPython %cpaste (input buffering: not all lines sent over)
+  " So this `write_paste_file` can help as a small lock & delay
+  call slime#common#write_paste_file(a:text)
+  call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
+  " if b:slime_config is {"jobid": ""} and not configured
+  " then unset it for automatic configuration next time
+  if b:slime_config["jobid"]  == ""
+    unlet b:slime_config
+  endif
+endfunction
+
+function! slime#targets#neovim#SlimeAddChannel()
+  if !exists("g:slime_last_channel")
+    let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
+  else
+    call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
+  endif
+endfunction
+
+function! slime#targets#neovim#SlimeClearChannel()
+  let current_buffer_jobid = &channel
+
+  let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
+        \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
+
+  for buf in related_bufs
+    call setbufvar(buf['bufnr'], 'slime_config', {})
+  endfor
+
+  if !exists("g:slime_last_channel")
+    if exists("b:slime_config")
       unlet b:slime_config
     endif
-  endfunction
-
-  function! slime#targets#neovim#SlimeAddChannel()
-    if !exists("g:slime_last_channel")
-      let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
-    else
-      call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
+    return
+  elseif len(g:slime_last_channel) == 1
+    unlet g:slime_last_channel
+    if exists("b:slime_config")
+      unlet b:slime_config
     endif
-  endfunction
+  else
+    let bufinfo = s:get_filter_bufinfo()
 
-  function! slime#targets#neovim#SlimeClearChannel()
-    let current_buffer_jobid = &channel
-
-    let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
-          \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
-
-    for buf in related_bufs
-      call setbufvar(buf['bufnr'], 'slime_config', {})
-    endfor
-
-    if !exists("g:slime_last_channel")
-      if exists("b:slime_config")
-        unlet b:slime_config
-      endif
-      return
-    elseif len(g:slime_last_channel) == 1
-      unlet g:slime_last_channel
-      if exists("b:slime_config")
-        unlet b:slime_config
-      endif
-    else
-      let bufinfo = s:get_filter_bufinfo()
-
-      " tests if using a version of Neovim that
-      " doesn't automatically close buffers when closed
-      " or there is no autocommand that does that
-      if len(bufinfo) == len(g:slime_last_channel)
-        call filter(bufinfo, {_, val -> val != current_buffer_jobid})
-      endif
-
-      call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
-
-    endif
-  endfunction
-
-
-
-  "evaluates whether ther is a terminal running; if there isn't then no config can be valid
-  function! slime#targets#neovim#ValidEnv() abort
-    if s:NotExistsLastChannel()
-      echon "Terminal not detected."
-      return 0
-    endif
-    return 1
-  endfunction
-
-  " "checks that a configuration is valid
-  " returns boolean of whether the supplied config is valid
-  function! slime#targets#neovim#ValidConfig(config) abort
-
-    if s:NotExistsLastChannel()
-      echon "\nTerminal not detected."
-      return 0
+    " tests if using a version of Neovim that
+    " doesn't automatically close buffers when closed
+    " or there is no autocommand that does that
+    if len(bufinfo) == len(g:slime_last_channel)
+      call filter(bufinfo, {_, val -> val != current_buffer_jobid})
     endif
 
-    if !exists("a:config") ||  a:config is v:null
-      echon "\nConfig does not exist."
-      return 0
+    call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
+
+  endif
+endfunction
+
+
+
+"evaluates whether ther is a terminal running; if there isn't then no config can be valid
+function! slime#targets#neovim#ValidEnv() abort
+  if s:NotExistsLastChannel()
+    echon "Terminal not detected."
+    return 0
+  endif
+  return 1
+endfunction
+
+" "checks that a configuration is valid
+" returns boolean of whether the supplied config is valid
+function! slime#targets#neovim#ValidConfig(config) abort
+
+  if s:NotExistsLastChannel()
+    echon "\nTerminal not detected."
+    return 0
+  endif
+
+  if !exists("a:config") ||  a:config is v:null
+    echon "\nConfig does not exist."
+    return 0
+  endif
+
+  " Ensure the config is a dictionary and a previous channel exists
+  if type(a:config) != v:t_dict
+    echon "\nConfig type not valid."
+    return 0
+  endif
+
+  if empty(a:config)
+    echon "\nConfig is empty."
+    return 0
+  endif
+
+  " Ensure the correct keys exist within the configuration
+  if !(has_key(a:config, 'jobid'))
+    echon "\nConfigration object lacks 'jobid'."
+    return 0
+  endif
+
+  if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
+    echon "\nNo matching job id for the provided pid."
+    return 0
+  endif
+
+  if !(index( s:last_channel_to_jobid_array(g:slime_last_channel), a:config['jobid']) >= 0)
+    echon "\nJob ID not found."
+    return 0
+  endif
+
+  if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
+    echon "\nJob ID not found."
+    return 0
+  endif
+
+  if empty(jobpid(a:config['jobid']))
+    echon "\nJob ID not linked to a PID."
+    return 0
+  endif
+
+  return 1
+
+endfunction
+
+
+function! s:last_channel_to_jobid_array(channel_dict)
+  return map(copy(a:channel_dict), {_, val -> val["jobid"]})
+endfunction
+
+" Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
+" for the purposes of input completion
+function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
+  "they will be transformed into pids so caling them by theier final identity
+  let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
+  return join(jobids,"\n")
+endfunction
+
+" Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job PIDs.
+" for the purposes of input completion
+function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
+  "they will be transformed into pids so caling them by theier final identity
+  let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
+  map(job_pids, {_, val -> s:translate_id_to_pid(val)})
+  call filter(job_pids, {_,val -> val != -1})
+  return join(jobpids,"\n")
+endfunction
+
+" Checks if a previous channel does not exist or is empty.
+function! s:NotExistsLastChannel() abort
+  return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
+endfunction
+
+
+function! s:get_filter_bufinfo()
+  let bufinfo = getbufinfo()
+  "getting terminal buffers
+
+  call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
+        \    && get(val,"listed",0)})
+  " only need the job id
+  call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
+
+  return bufinfo
+endfunction
+
+function! s:translate_pid_to_id(pid)
+  for ch in g:slime_last_channel
+    if ch['pid'] == a:pid
+      return ch['jobid']
     endif
+  endfor
+  return -1
+endfunction
 
-    " Ensure the config is a dictionary and a previous channel exists
-    if type(a:config) != v:t_dict
-      echon "\nConfig type not valid."
-      return 0
-    endif
-
-    if empty(a:config)
-      echon "\nConfig is empty."
-      return 0
-    endif
-
-    " Ensure the correct keys exist within the configuration
-    if !(has_key(a:config, 'jobid'))
-      echon "\nConfigration object lacks 'jobid'."
-      return 0
-    endif
-
-    if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
-      echon "\nNo matching job id for the provided pid."
-      return 0
-    endif
-
-    if !(index( s:last_channel_to_jobid_array(g:slime_last_channel), a:config['jobid']) >= 0)
-      echon "\nJob ID not found."
-      return 0
-    endif
-
-    if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
-      echon "\nJob ID not found."
-      return 0
-    endif
-
-    if empty(jobpid(a:config['jobid']))
-      echon "\nJob ID not linked to a PID."
-      return 0
-    endif
-
-    return 1
-
-  endfunction
-
-
-  function! s:last_channel_to_jobid_array(channel_dict)
-    return map(copy(a:channel_dict), {_, val -> val["jobid"]})
-  endfunction
-
-  " Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
-  " for teh purposes of input completion
-  function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
-    "they will be transformed into pids so caling them by theier final identity
-    let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
-    return join(jobids,"\n")
-  endfunction
-
-  " Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job PIDs.
-  " for the purposes of input completion
-  function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
-    "they will be transformed into pids so caling them by theier final identity
-    let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
-    map(job_pids, {_, val -> s:translate_id_to_pid(val)})
-    call filter(job_pids, {_,val -> val != -1})
-    return join(jobpids,"\n")
-  endfunction
-
-  " Checks if a previous channel does not exist or is empty.
-  function! s:NotExistsLastChannel() abort
-    return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
-  endfunction
-
-
-  function! s:get_filter_bufinfo()
-    let bufinfo = getbufinfo()
-    "getting terminal buffers
-
-    call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
-          \    && get(val,"listed",0)})
-    " only need the job id
-    call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
-
-    return bufinfo
-  endfunction
-
-  function! s:translate_pid_to_id(pid)
-    for ch in g:slime_last_channel
-      if ch['pid'] == a:pid
-        return ch['jobid']
-      endif
-    endfor
-    return -1
-  endfunction
-
-  function! s:translate_id_to_pid(id)
+function! s:translate_id_to_pid(id)
+  let pid_out = -1
+  try
+    let pid_out = jobpid(a:id)
+  catch /E900: Invalid channel id/
     let pid_out = -1
-    try
-      let pid_out = jobpid(a:id)
-    catch /E900: Invalid channel id/
-      let pid_out = -1
-    endtry
-    return pid_out
-  endfunction
+  endtry
+  return pid_out
+endfunction

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -89,7 +89,7 @@ endfunction
 "evaluates whether ther is a terminal running; if there isn't then no config can be valid
 function! slime#targets#neovim#ValidEnv() abort
   if s:NotExistsLastChannel()
-    echon "Terminal not detected: Open a Neovim terminal and try again. "
+    echon "Terminal not detected."
     return 0
   endif
   return 1
@@ -100,7 +100,7 @@ endfunction
 function! slime#targets#neovim#ValidConfig(config) abort
 
   if s:NotExistsLastChannel()
-    echon "\rTerminal not detected: Open a neovim terminal and try again. "
+    echon "\rTerminal not detected."
     return 0
   endif
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -104,7 +104,8 @@ endfunction
 function! slime#targets#neovim#ValidConfig(config) abort
   "config is passed as a string, the name of the config variable
 
-  if !slime#targets#neovim#ValidEnv()
+  if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
+    echo "Terminal not found."
     return 0
   endif
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -65,6 +65,8 @@ function! slime#targets#neovim#config() abort
 
     let b:slime_config = temp_config
 
+    " second 0 argument means we are not clearing the config;
+    " we don't clear because base 'send' requires existence of b:sime_config
     call s:protected_validation_and_clear(0,0)
 
 
@@ -93,7 +95,8 @@ function! s:protected_validation_and_clear(silent, clear_current)
 endfunction
 
 function! slime#targets#neovim#send(config, text) abort
-  " existence is checked for in the base function
+  " existence of 'b:config' is implicitly assumed by the base send function
+  " if it doesn't exist there will have been an error before reaching this code
   if slime#targets#neovim#ValidConfig(a:config,0)
     " Neovim jobsend is fully asynchronous, it causes some problems with
     " iPython %cpaste (input buffering: not all lines sent over)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -104,17 +104,16 @@ endfunction
 function! slime#targets#neovim#ValidConfig(config) abort
   "config is passed as a string, the name of the config variable
 
+  if !slime#targets#neovim#ValidEnv()
+    return 0
+  endif
+
   if !exists(a:config)
     echo "No config found."
     return 0
   else
 
     let config_in = eval(a:config)
-
-    if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
-      echo "Terminal not found."
-      return 0
-    endif
 
     " Ensure the config is a dictionary and a previous channel exists
     if type(config_in) != v:t_dict

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -72,14 +72,10 @@ endfunction
 
 function! slime#targets#neovim#SlimeClearChannel(buf_in) abort
   if !exists("g:slime_last_channel")
-    call s:clear_all_buffs()
     return
   elseif len(g:slime_last_channel) <= 1
-    call s:clear_all_buffs()
     unlet g:slime_last_channel
   else
-    let jobid_to_clear = filter(copy(g:slime_last_channel), {_, val -> val['bufnr'] == a:buf_in})[0]['jobid']
-    call s:clear_related_bufs(jobid_to_clear)
     call filter(g:slime_last_channel, {_, val -> val['bufnr'] != a:buf_in})
   endif
 endfunction
@@ -136,7 +132,7 @@ function! slime#targets#neovim#ValidConfig(config) abort
           \map(copy(g:slime_last_channel), {_, val -> val["jobid"]}),
           \config_in['jobid']) >= 0
           \)
-      echo "Job ID not found."
+      echo "Invalid job ID."
       return 0
     endif
 
@@ -187,25 +183,6 @@ function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos) abort
   return reverse(jobpids) "making most recent the first selected
 endfunction
 
-
-" clears all buffers with a certain invalid configuration
-function! s:clear_related_bufs(id_in) abort
-  let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
-        \ && get(val['variables']['slime_config'], 'jobid', -2) == a:id_in})
-
-  for buf in related_bufs
-    call setbufvar(buf['bufnr'], 'slime_config', {})
-  endfor
-endfunction
-
-" clears all buffers with a certain invalid configuration
-function! s:clear_all_buffs() abort
-  let target_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config") })
-
-  for buf in target_bufs
-    call setbufvar(buf['bufnr'], 'slime_config', {})
-  endfor
-endfunction
 
 function! s:extend_term_buffer_titles(specific_term_info, all_bufinfo) abort
   " add buffer name and terminal title to a dictionary that already has jobid, pid, buffer number

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -3,7 +3,6 @@ function! slime#targets#neovim#config() abort
   let config_set = 0
   if slime#targets#neovim#ValidEnv()
 
-    "1
     call s:protected_validation_and_clear(1,1)
 
     if exists("g:slime_menu_config") && g:slime_menu_config && !config_set

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -18,185 +18,189 @@ function! slime#targets#neovim#config() abort
     "validation of the environment with ValidEnv should prevent the empty string
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
-    end
-    let pid_in = input("pid: ", default_pid)
+      end
+      let pid_in = input("pid: ", default_pid)
 
-    let id_in = s:translate_pid_to_id(pid_in)
-  else
-    if exists("g:slime_get_jobid")
-      let id_in = g:slime_get_jobid()
+      let id_in = s:translate_pid_to_id(pid_in)
     else
-      let id_in = input("Configuring vim-slime. Input jobid: ", str2nr(b:slime_config["jobid"]))
-      let id_in = str2nr(id_in)
+      if exists("g:slime_get_jobid")
+        let id_in = g:slime_get_jobid()
+      else
+        let default_jobid = b:slime_config["jobid"]
+        if !empty(default_jobid)
+          let default_jobid = str2nr(default_jobid)
+        endif
+        let id_in = input("jobid: ", default_jobid)
+        let id_in = str2nr(id_in)
+      endif
+      let pid_in = s:translate_id_to_pid(id_in)
     endif
-    let pid_in = s:translate_id_to_pid(id_in)
-  endif
 
-  let b:slime_config["jobid"] = id_in
-  let b:slime_config["pid"] = pid_in
-endfunction
+    let b:slime_config["jobid"] = id_in
+    let b:slime_config["pid"] = pid_in
+  endfunction
 
-function! slime#targets#neovim#send(config, text)
-  " Neovim jobsend is fully asynchronous, it causes some problems with
-  " iPython %cpaste (input buffering: not all lines sent over)
-  " So this `write_paste_file` can help as a small lock & delay
-  call slime#common#write_paste_file(a:text)
-  call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
-  " if b:slime_config is {"jobid": ""} and not configured
-  " then unset it for automatic configuration next time
-  if b:slime_config["jobid"]  == ""
-    unlet b:slime_config
-  endif
-endfunction
-
-function! slime#targets#neovim#SlimeAddChannel()
-  if !exists("g:slime_last_channel")
-    let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
-  else
-    call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
-  endif
-endfunction
-
-function! slime#targets#neovim#SlimeClearChannel()
-  let current_buffer_jobid = &channel
-
-  let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
-        \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
-
-  for buf in related_bufs
-    call setbufvar(buf['bufnr'], 'slime_config', {})
-  endfor
-
-  if !exists("g:slime_last_channel")
-    if exists("b:slime_config")
+  function! slime#targets#neovim#send(config, text)
+    " Neovim jobsend is fully asynchronous, it causes some problems with
+    " iPython %cpaste (input buffering: not all lines sent over)
+    " So this `write_paste_file` can help as a small lock & delay
+    call slime#common#write_paste_file(a:text)
+    call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
+    " if b:slime_config is {"jobid": ""} and not configured
+    " then unset it for automatic configuration next time
+    if b:slime_config["jobid"]  == ""
       unlet b:slime_config
     endif
-    return
-  elseif len(g:slime_last_channel) == 1
-    unlet g:slime_last_channel
-    if exists("b:slime_config")
-      unlet b:slime_config
+  endfunction
+
+  function! slime#targets#neovim#SlimeAddChannel()
+    if !exists("g:slime_last_channel")
+      let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
+    else
+      call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
     endif
-  else
-    let bufinfo = s:get_filter_bufinfo()
+  endfunction
 
-    " tests if using a version of Neovim that
-    " doesn't automatically close buffers when closed
-    " or there is no autocommand that does that
-    if len(bufinfo) == len(g:slime_last_channel)
-      call filter(bufinfo, {_, val -> val != current_buffer_jobid})
+  function! slime#targets#neovim#SlimeClearChannel()
+    let current_buffer_jobid = &channel
+
+    let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
+          \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
+
+    for buf in related_bufs
+      call setbufvar(buf['bufnr'], 'slime_config', {})
+    endfor
+
+    if !exists("g:slime_last_channel")
+      if exists("b:slime_config")
+        unlet b:slime_config
+      endif
+      return
+    elseif len(g:slime_last_channel) == 1
+      unlet g:slime_last_channel
+      if exists("b:slime_config")
+        unlet b:slime_config
+      endif
+    else
+      let bufinfo = s:get_filter_bufinfo()
+
+      " tests if using a version of Neovim that
+      " doesn't automatically close buffers when closed
+      " or there is no autocommand that does that
+      if len(bufinfo) == len(g:slime_last_channel)
+        call filter(bufinfo, {_, val -> val != current_buffer_jobid})
+      endif
+
+      call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
+
+    endif
+  endfunction
+
+
+
+  "evaluates whether ther is a terminal running; if there isn't then no config can be valid
+  function! slime#targets#neovim#ValidEnv() abort
+    if s:NotExistsLastChannel()
+      echon "Terminal not detected."
+      return 0
+    endif
+    return 1
+  endfunction
+
+  " "checks that a configuration is valid
+  " returns boolean of whether the supplied config is valid
+  function! slime#targets#neovim#ValidConfig(config) abort
+
+    if s:NotExistsLastChannel()
+      echon "\nTerminal not detected."
+      return 0
     endif
 
-    call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
-
-  endif
-endfunction
-
-
-
-"evaluates whether ther is a terminal running; if there isn't then no config can be valid
-function! slime#targets#neovim#ValidEnv() abort
-  if s:NotExistsLastChannel()
-    echon "Terminal not detected."
-    return 0
-  endif
-  return 1
-endfunction
-
-" "checks that a configuration is valid
-" returns boolean of whether the supplied config is valid
-function! slime#targets#neovim#ValidConfig(config) abort
-
-  if s:NotExistsLastChannel()
-    echon "\nTerminal not detected."
-    return 0
-  endif
-
-  if !exists("a:config") ||  a:config is v:null
-    echon "\nConfig does not exist."
-    return 0
-  endif
-
-  " Ensure the config is a dictionary and a previous channel exists
-  if type(a:config) != v:t_dict
-    echon "\nConfig type not valid."
-    return 0
-  endif
-
-  if empty(a:config)
-    echon "\nConfig is empty."
-    return 0
-  endif
-
-  " Ensure the correct keys exist within the configuration
-  if !(has_key(a:config, 'jobid'))
-    echon "\nConfigration object lacks 'jobid'."
-    return 0
-  endif
-
-  if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
-    echon "\nNo matching job id for the provided pid."
-    return 0
-  endif
-
-  if !(index( s:channel_to_array(g:slime_last_channel), a:config['jobid']) >= 0)
-    echon "\nJob ID not found."
-    return 0
-  endif
-
-  if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
-    echon "\nJob ID not found."
-    return 0
-  endif
-
-  if empty(jobpid(a:config['jobid']))
-    echon "\nJob ID not linked to a PID."
-    return 0
-  endif
-
-  return 1
-
-endfunction
-
-
-" Transforms a channel dictionary into an array of job IDs.
-function! s:channel_to_array(channel_dict)
-  return map(copy(a:channel_dict), {_, val -> val["jobid"]})
-endfunction
-
-" Checks if a previous channel does not exist or is empty.
-function! s:NotExistsLastChannel() abort
-  return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
-endfunction
-
-
-function! s:get_filter_bufinfo()
-  let bufinfo = getbufinfo()
-  "getting terminal buffers
-
-  call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
-        \    && get(val,"listed",0)})
-  " only need the job id
-  call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
-
-  return bufinfo
-endfunction
-
-function! s:translate_pid_to_id(pid)
-  for ch in g:slime_last_channel
-    if ch['pid'] == a:pid
-      return ch['jobid']
+    if !exists("a:config") ||  a:config is v:null
+      echon "\nConfig does not exist."
+      return 0
     endif
-  endfor
-  return -1
-endfunction
 
-function! s:translate_id_to_pid(id)
-  let pid_out = -1
-  try
-    let pid_out = jobpid(a:id)
-  catch /E900: Invalid channel id/
+    " Ensure the config is a dictionary and a previous channel exists
+    if type(a:config) != v:t_dict
+      echon "\nConfig type not valid."
+      return 0
+    endif
+
+    if empty(a:config)
+      echon "\nConfig is empty."
+      return 0
+    endif
+
+    " Ensure the correct keys exist within the configuration
+    if !(has_key(a:config, 'jobid'))
+      echon "\nConfigration object lacks 'jobid'."
+      return 0
+    endif
+
+    if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
+      echon "\nNo matching job id for the provided pid."
+      return 0
+    endif
+
+    if !(index( s:channel_to_array(g:slime_last_channel), a:config['jobid']) >= 0)
+      echon "\nJob ID not found."
+      return 0
+    endif
+
+    if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
+      echon "\nJob ID not found."
+      return 0
+    endif
+
+    if empty(jobpid(a:config['jobid']))
+      echon "\nJob ID not linked to a PID."
+      return 0
+    endif
+
+    return 1
+
+  endfunction
+
+
+  " Transforms a channel dictionary into an array of job IDs.
+  function! s:channel_to_array(channel_dict)
+    return map(copy(a:channel_dict), {_, val -> val["jobid"]})
+  endfunction
+
+  " Checks if a previous channel does not exist or is empty.
+  function! s:NotExistsLastChannel() abort
+    return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
+  endfunction
+
+
+  function! s:get_filter_bufinfo()
+    let bufinfo = getbufinfo()
+    "getting terminal buffers
+
+    call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
+          \    && get(val,"listed",0)})
+    " only need the job id
+    call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
+
+    return bufinfo
+  endfunction
+
+  function! s:translate_pid_to_id(pid)
+    for ch in g:slime_last_channel
+      if ch['pid'] == a:pid
+        return ch['jobid']
+      endif
+    endfor
+    return -1
+  endfunction
+
+  function! s:translate_id_to_pid(id)
     let pid_out = -1
-  endtry
-  return pid_out
-endfunction
+    try
+      let pid_out = jobpid(a:id)
+    catch /E900: Invalid channel id/
+      let pid_out = -1
+    endtry
+    return pid_out
+  endfunction

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -154,7 +154,6 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
   echohl WarningMsg
   if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
     if !a:silent
-      
       echo "Terminal not found."
     endif
     echohl none
@@ -165,7 +164,6 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
   " Ensure the config is a dictionary and a previous channel exists
   if type(a:config) != v:t_dict
     if !a:silent
-      
       echo "Config type not valid."
     endif
     echohl none
@@ -174,7 +172,6 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
 
   if empty(a:config)
     if !a:silent
-      
       echo "Config is empty."
     endif
     echohl none
@@ -184,7 +181,6 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
   " Ensure the correct keys exist within the configuration
   if !(has_key(a:config, 'jobid'))
     if !a:silent
-      
       echo "Configration object lacks 'jobid'."
     endif
     echohl none
@@ -193,7 +189,6 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
 
   if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
     if !a:silent
-      
       echo "No matching job id for the provided pid."
     endif
     echohl none
@@ -205,7 +200,6 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
         \a:config['jobid']) >= 0
         \)
     if !a:silent
-      
       echo "Invalid Job ID."
     endif
     echohl none
@@ -214,7 +208,6 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
 
   if s:translate_id_to_pid(a:config['jobid']) == -1
     if !a:silent
-      
       echo "Job ID not linked to a PID."
     endif
     echohl none

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -138,13 +138,10 @@ endfunction
 
 " evaluates whether there is a terminal running; if there isn't then no config can be valid
 function! slime#targets#neovim#ValidEnv() abort
-  echohl WarningMsg
   if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
-    echo "Terminal not found."
-    echohl none
+    call s:EchoWarningMsg("Terminal not found.")
     return 0
   endif
-  echohl none
   return 1
 endfunction
 
@@ -152,12 +149,10 @@ endfunction
 " returns boolean of whether the supplied config is valid
 function! slime#targets#neovim#ValidConfig(config, silent) abort
 
-  echohl WarningMsg
   if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
     if !a:silent
-      echo "Terminal not found."
+      call s:EchoWarningMsg("Terminal not found.")
     endif
-    echohl none
     return 0
   endif
 
@@ -165,34 +160,30 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
   " Ensure the config is a dictionary and a previous channel exists
   if type(a:config) != v:t_dict
     if !a:silent
-      echo "Config type not valid."
+      call s:EchoWarningMsg("Config type not valid.")
     endif
-    echohl none
     return 0
   endif
 
   if empty(a:config)
     if !a:silent
-      echo "Config is empty."
+      call s:EchoWarningMsg("Config is empty.")
     endif
-    echohl none
     return 0
   endif
 
   " Ensure the correct keys exist within the configuration
   if !(has_key(a:config, 'jobid'))
     if !a:silent
-      echo "Config object lacks 'jobid'."
+      call s:EchoWarningMsg("Config object lacks 'jobid'.")
     endif
-    echohl none
     return 0
   endif
 
   if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
     if !a:silent
-      echo "No matching job ID for the provided pid."
+      call s:EchoWarningMsg("No matching job ID for the provided pid.")
     endif
-    echohl none
     return 0
   endif
 
@@ -201,21 +192,18 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
         \a:config['jobid']) >= 0
         \)
     if !a:silent
-      echo "Invalid job ID."
+      call s:EchoWarningMsg("Invalid job ID.")
     endif
-    echohl none
     return 0
   endif
 
   if s:translate_id_to_pid(a:config['jobid']) == -1
     if !a:silent
-      echo "job ID not linked to a PID."
+      call s:EchoWarningMsg("job ID not linked to a PID.")
     endif
-    echohl none
     return 0
   endif
 
-  echohl None
 
   return 1
 endfunction
@@ -372,4 +360,12 @@ function! s:sure_clear_buf_config()
   if exists('b:slime_config')  && type(b:slime_config) == v:t_dict && !empty(b:slime_config) && has_key(b:slime_config, 'jobid') && type(b:slime_config['jobid']) == v:t_number
     call s:clear_related_bufs(b:slime_config['jobid'])
   endif
+endfunction
+
+
+
+function! s:EchoWarningMsg(msg)
+    echohl WarningMsg
+    echo a:msg
+    echohl None
 endfunction

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -12,7 +12,15 @@ function! slime#targets#neovim#config() abort
 
   " include option to input pid
   if exists("g:slime_input_pid") && g:slime_input_pid
-    let pid_in = input("Configuring vim-slime. Input pid: ", str2nr(jobpid(b:slime_config["jobid"])))
+
+    let default_pid = jobpid(b:slime_config["jobid"])
+    "if everything does right this validation should be redundant
+    "validation of the environment with ValidEnv should prevent the empty string
+    if !empty(default_pid)
+      let default_pid = str2nr(default_pid)
+    end
+    let pid_in = input("pid: ", default_pid)
+
     let id_in = s:translate_pid_to_id(pid_in)
   else
     if exists("g:slime_get_jobid")

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -173,7 +173,6 @@ function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
   "they will be transformed into pids so caling them by theier final identity
   let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
   return join(jobids,"\n")
-
 endfunction
 
 " Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job PIDs.
@@ -184,7 +183,6 @@ function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
   map(job_pids, {_, val -> s:translate_id_to_pid(val)})
   call filter(job_pids, {_,val -> val != -1})
   return join(jobpids,"\n")
-
 endfunction
 
   " Checks if a previous channel does not exist or is empty.

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -211,8 +211,8 @@ function! s:extend_term_buffer_titles(specific_term_info, all_bufinfo) abort
   " all_bufinfo is the output of getbufinfo()
 
   " important to use copy here to avoid filtering in calling environment
-  let all_bufinfo_in = copy(all_bufinfo)
-  let specific_term_info_in = copy(specific_term_info)
+  let all_bufinfo_in = copy(a:all_bufinfo)
+  let specific_term_info_in = copy(a:specific_term_info)
 
   " get the term info
   let wanted_term = filter(all_bufinfo_in, {_, val -> val['bufnr'] == specific_term_info_in['bufnr']})[0]

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -204,7 +204,6 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
     return 0
   endif
 
-
   return 1
 endfunction
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -167,14 +167,14 @@ function! s:last_channel_to_jobid_array(channel_dict)
   return map(copy(a:channel_dict), {_, val -> val["jobid"]})
 endfunction
 
-" Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
+" Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
 " for the purposes of input completion
 function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
   let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
   return join(jobids,"\n")
 endfunction
 
-" Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job PIDs.
+" Transforms a channel dictionary with job ida and pid into an newline separated string  of job PIDs.
 " for the purposes of input completion
 function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
   "they will be transformed into pids so caling them by their final identity

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -69,11 +69,9 @@ function! slime#targets#neovim#SlimeClearChannel(buf_in)
   let bufinfo = getbufinfo()
 
   if !exists("g:slime_last_channel")
-    echom "slime last channel not found"
     call s:clear_all_buffs()
     return
   elseif len(g:slime_last_channel) <= 1
-    echom "len slime last chanel is one or less"
     call s:clear_all_buffs()
     let g:slime_last_channel = []
   else

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -50,7 +50,7 @@ function! slime#targets#neovim#config() abort
   let b:slime_config["pid"] = pid_in
 endfunction
 
-function! slime#targets#neovim#send(config, text)
+function! slime#targets#neovim#send(config, text) abort
   " Neovim jobsend is fully asynchronous, it causes some problems with
   " iPython %cpaste (input buffering: not all lines sent over)
   " So this `write_paste_file` can help as a small lock & delay
@@ -58,7 +58,7 @@ function! slime#targets#neovim#send(config, text)
   call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
 endfunction
 
-function! slime#targets#neovim#SlimeAddChannel(buf_in)
+function! slime#targets#neovim#SlimeAddChannel(buf_in) abort
   let buf_in = str2nr(a:buf_in)
   let jobid = getbufvar(buf_in, "&channel")
   let job_pid = jobpid(jobid)
@@ -70,7 +70,7 @@ function! slime#targets#neovim#SlimeAddChannel(buf_in)
   endif
 endfunction
 
-function! slime#targets#neovim#SlimeClearChannel(buf_in)
+function! slime#targets#neovim#SlimeClearChannel(buf_in) abort
   if !exists("g:slime_last_channel")
     call s:clear_all_buffs()
     return
@@ -148,7 +148,7 @@ function! slime#targets#neovim#ValidConfig(config) abort
   return 1
 endfunction
 
-function! s:translate_pid_to_id(pid)
+function! s:translate_pid_to_id(pid) abort
   for ch in g:slime_last_channel
     if ch['pid'] == a:pid
       return ch['jobid']
@@ -157,7 +157,7 @@ function! s:translate_pid_to_id(pid)
   return -1
 endfunction
 
-function! s:translate_id_to_pid(id)
+function! s:translate_id_to_pid(id) abort
   let pid_out = -1
   try
     let pid_out = jobpid(a:id)
@@ -168,7 +168,7 @@ endfunction
 
 " Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
 " for the purposes of input completion
-function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos)
+function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos) abort
   let jobids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
   call map(jobids, {_, val -> string(val)})
   return jobids
@@ -176,7 +176,7 @@ endfunction
 
 " Transforms a channel dictionary with job ida and pid into an newline separated string  of job PIDs.
 " for the purposes of input completion
-function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos)
+function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos) abort
   "they will be transformed into pids so naming them by their final identity
   let jobpids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
   call map(jobpids, {_, val -> s:translate_id_to_pid(val)})
@@ -187,7 +187,7 @@ endfunction
 
 
 " clears all buffers with a certain invalid configuration
-function! s:clear_related_bufs(id_in)
+function! s:clear_related_bufs(id_in) abort
   let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
         \ && get(val['variables']['slime_config'], 'jobid', -2) == a:id_in})
 
@@ -197,7 +197,7 @@ function! s:clear_related_bufs(id_in)
 endfunction
 
 " clears all buffers with a certain invalid configuration
-function! s:clear_all_buffs()
+function! s:clear_all_buffs() abort
   let target_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config") })
 
   for buf in target_bufs
@@ -205,7 +205,7 @@ function! s:clear_all_buffs()
   endfor
 endfunction
 
-function! s:extend_term_buffer_titles(specific_term_info, all_bufinfo)
+function! s:extend_term_buffer_titles(specific_term_info, all_bufinfo) abort
   " add buffer name and terminal title to a dictionary that already has jobid, pid, buffer number
   "specific term info is a dictionary that contains jobid, pid, and bufnr
   " all_bufinfo is the output of getbufinfo()
@@ -220,7 +220,7 @@ function! s:extend_term_buffer_titles(specific_term_info, all_bufinfo)
 endfunction
 
 
-function! s:buffer_dictionary_to_string(dict_in)
+function! s:buffer_dictionary_to_string(dict_in) abort
   " dict in is an array of dictionaries that has the values of the menu items
 
   "menu order is an array of dictionaries
@@ -257,7 +257,7 @@ endfunction
 
 
 "get full bufinfo only of terminal buffers
-function! s:get_terminal_bufinfo()
+function! s:get_terminal_bufinfo() abort
   if !exists("g:slime_last_channel") || len(g:slime_last_channel) == 0 || empty(g:slime_last_channel)
     "there are no valid terminal buffers
     return []
@@ -268,7 +268,7 @@ function! s:get_terminal_bufinfo()
 endfunction
 
 
-function! s:config_with_menu()
+function! s:config_with_menu() abort
   " get info of running terminals, array of dictionaries
   let term_bufinfo = s:get_terminal_bufinfo()
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -170,7 +170,6 @@ endfunction
 " Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
 " for the purposes of input completion
 function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
-  "they will be transformed into pids so caling them by theier final identity
   let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
   return join(jobids,"\n")
 endfunction
@@ -178,7 +177,7 @@ endfunction
 " Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job PIDs.
 " for the purposes of input completion
 function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
-  "they will be transformed into pids so caling them by theier final identity
+  "they will be transformed into pids so caling them by their final identity
   let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
   map(job_pids, {_, val -> s:translate_id_to_pid(val)})
   call filter(job_pids, {_,val -> val != -1})

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -1,43 +1,47 @@
 
 function! slime#targets#neovim#config() abort
 
-  " unlet current config if its jobid doesn't exist
-  let last_channels = get(g:, 'slime_last_channel', [])
-  let most_recent_channel = get(last_channels, -1, {})
-
-  let last_pid = get(most_recent_channel, 'pid', '')
-  let last_job = get(most_recent_channel, 'jobid', '')
-
-  let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
-
-  " include option to input pid
-  if exists("g:slime_input_pid") && g:slime_input_pid
-
-    let default_pid = jobpid(b:slime_config["jobid"])
-    "if everything does right this validation should be redundant
-    "validation of the environment with ValidEnv should prevent the empty string
-    if !empty(default_pid)
-      let default_pid = str2nr(default_pid)
-    endif
-    let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
-
-    let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
+  if exists("g:slime_menu_config") && g:slime_menu_config
+    call s:config_with_list()
   else
-    if exists("g:slime_get_jobid")
-      let jobid_in = g:slime_get_jobid()
-    else
-      let default_jobid = b:slime_config["jobid"]
-      if !empty(default_jobid)
-        let default_jobid = str2nr(default_jobid)
-      endif
-      let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
-      let jobid_in = str2nr(jobid_in)
-    endif
-    let pid_in = s:translate_id_to_pid(jobid_in)
-  endif
+    " unlet current config if its jobid doesn't exist
+    let last_channels = get(g:, 'slime_last_channel', [])
+    let most_recent_channel = get(last_channels, -1, {})
 
-  let b:slime_config["jobid"] = jobid_in
-  let b:slime_config["pid"] = pid_in
+    let last_pid = get(most_recent_channel, 'pid', '')
+    let last_job = get(most_recent_channel, 'jobid', '')
+
+    let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
+
+    " include option to input pid
+    if exists("g:slime_input_pid") && g:slime_input_pid
+
+      let default_pid = jobpid(b:slime_config["jobid"])
+      "if everything does right this validation should be redundant
+      "validation of the environment with ValidEnv should prevent the empty string
+      if !empty(default_pid)
+        let default_pid = str2nr(default_pid)
+      endif
+      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
+
+      let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
+    else
+      if exists("g:slime_get_jobid")
+        let jobid_in = g:slime_get_jobid()
+      else
+        let default_jobid = b:slime_config["jobid"]
+        if !empty(default_jobid)
+          let default_jobid = str2nr(default_jobid)
+        endif
+        let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
+        let jobid_in = str2nr(jobid_in)
+      endif
+      let pid_in = s:translate_id_to_pid(jobid_in)
+    endif
+
+    let b:slime_config["jobid"] = jobid_in
+    let b:slime_config["pid"] = pid_in
+  endif
 endfunction
 
 function! slime#targets#neovim#send(config, text)
@@ -91,7 +95,7 @@ endfunction
 "evaluates whether ther is a terminal running; if there isn't then no config can be valid
 function! slime#targets#neovim#ValidEnv() abort
   if s:NotExistsLastChannel()
-    echon "Terminal not detected."
+    echon "Terminal not found."
     return 0
   endif
   return 1
@@ -100,56 +104,62 @@ endfunction
 " "checks that a configuration is valid
 " returns boolean of whether the supplied config is valid
 function! slime#targets#neovim#ValidConfig(config) abort
-
-  if s:NotExistsLastChannel()
-    echon "\nTerminal not detected."
+  if !exists(a:config)
+    echo "\nNo config found."
     return 0
-  endif
+  else
+    let config_in = eval(a:config)
 
-  if !exists("a:config") ||  a:config is v:null
-    echon "\nConfig does not exist."
-    return 0
-  endif
+    if s:NotExistsLastChannel()
+      echo "\nTerminal not found."
+      return 0
+    endif
 
-  " Ensure the config is a dictionary and a previous channel exists
-  if type(a:config) != v:t_dict
-    echon "\nConfig type not valid."
-    return 0
-  endif
+    if !exists("config_in") ||  config_in is v:null
+      echo "\nConfig does not exist."
+      return 0
+    endif
 
-  if empty(a:config)
-    echon "\nConfig is empty."
-    return 0
-  endif
+    " Ensure the config is a dictionary and a previous channel exists
+    if type(config_in) != v:t_dict
+      echo "\nConfig type not valid."
+      return 0
+    endif
 
-  " Ensure the correct keys exist within the configuration
-  if !(has_key(a:config, 'jobid'))
-    echon "\nConfigration object lacks 'jobid'."
-    return 0
-  endif
+    if empty(config_in)
+      echo "\nConfig is empty."
+      return 0
+    endif
 
-  if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
-    echon "\nNo matching job id for the provided pid."
-    return 0
-  endif
+    " Ensure the correct keys exist within the configuration
+    if !(has_key(config_in, 'jobid'))
+      echo "\nConfigration object lacks 'jobid'."
+      return 0
+    endif
 
-  if !(index( s:last_channel_to_jobid_array(g:slime_last_channel), a:config['jobid']) >= 0)
-    echon "\nJob ID not found."
-    return 0
-  endif
+    if config_in["jobid"] == -1  "the id wasn't found translate_pid_to_id
+      echo "\nNo matching job id for the provided pid."
+      return 0
+    endif
 
-  if !(index(s:get_terminal_jobids(), a:config['jobid']) >= 0)
-    echon "\nJob ID not found."
-    return 0
-  endif
+    if !(index( s:last_channel_to_jobid_array(g:slime_last_channel), config_in['jobid']) >= 0)
+      echo "\nJob ID not found."
+      return 0
+    endif
 
-  if empty(jobpid(a:config['jobid']))
-    echon "\nJob ID not linked to a PID."
-    return 0
+    if !(index(s:get_terminal_jobids(), config_in['jobid']) >= 0)
+      echo "\nJob ID not found."
+      return 0
+    endif
+
+    if empty(jobpid(config_in['jobid']))
+      echo "\nJob ID not linked to a PID."
+      return 0
+    endif
+
   endif
 
   return 1
-
 endfunction
 
 
@@ -167,7 +177,6 @@ function! s:translate_id_to_pid(id)
   try
     let pid_out = jobpid(a:id)
   catch /E900: Invalid channel id/
-    let pid_out = -1
   endtry
   return pid_out
 endfunction
@@ -185,14 +194,11 @@ function! s:get_terminal_jobids()
   call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
         \    && get(val,"listed",0)})
   " only need the job id
-  call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
+  call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] }) "it is numeric
 
   return bufinfo
 endfunction
 
-function! s:last_channel_to_jobid_array(channel_dict)
-  return map(copy(a:channel_dict), {_, val -> val["jobid"]})
-endfunction
 
 " Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
 " for the purposes of input completion
@@ -214,6 +220,12 @@ function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos)
 endfunction
 
 
+
+function! s:last_channel_to_jobid_array(channel_dict)
+  return map(copy(a:channel_dict), {_, val -> val["jobid"]})
+endfunction
+
+
 " clears all buffers with a certain invalid configuration
 function! s:clear_related_bufs(id_in)
   let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
@@ -223,3 +235,70 @@ function! s:clear_related_bufs(id_in)
     call setbufvar(buf['bufnr'], 'slime_config', {})
   endfor
 endfunction
+
+
+function! s:extract_buffer_details(buffer)
+  let details = {}
+  let details['name'] = get(a:buffer, 'name', 'N/A')
+  let vars = get(a:buffer, 'variables', {})
+  let details['term_title'] = get(vars, 'term_title', 'N/A')
+  let details['jobid'] = get(vars, 'terminal_job_id', 0)
+  return details
+endfunction
+
+
+function! s:buffer_dictionary_to_string(dict_in)
+  if exists('g:slime_neovim_menu_order')
+    let menu_order = g:slime_neovim_menu_order
+  else
+    let menu_order = [{'pid': 'pid: '},{'jobid':'jobid: '},{'term_title':''},{'name':''}]
+  endif
+
+  if exists('g:slime_neovim_menu_delimiter')
+    let delimiter = g:slime_neovim_menu_delimiter
+  else
+    let delimiter = ', '
+  endif
+
+  let menu_string = ''
+
+  for i in range(len(menu_order))
+    let menu_item = menu_order[i]
+    let key = keys(menu_order[i])[0]
+    if i != len(menu_order) - 1
+      let menu_string = menu_string . menu_item[key] . a:dict_in[key] . delimiter
+    else
+      let menu_string = menu_string . menu_item[key] . a:dict_in[key]
+    endif
+  endfor
+
+  return menu_string
+endfunction
+
+function! s:config_with_list()
+  let bufinfo = getbufinfo()
+  call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id") && get(val,"listed",0)})
+  call map(bufinfo, { _, val -> s:extract_buffer_details(val)})
+  let valid_job_ids = s:last_channel_to_jobid_array(g:slime_last_channel)
+  call filter(bufinfo, {_, val -> index( valid_job_ids, val['jobid']) >= 0})
+  call map(bufinfo, {_, val -> extend(val, {'pid': s:translate_id_to_pid(val['jobid'])})})
+  call filter(bufinfo, {_, val ->  val['pid'] != -1})
+  let valid_configs =  map(copy(bufinfo), {_, val ->  {'jobid': val['jobid'], 'pid': val['pid']}})
+  call map(bufinfo, {_, val -> s:buffer_dictionary_to_string(val)})
+  for i in range(1, len(bufinfo))
+    let bufinfo[i - 1] = i . '. ' . bufinfo[i - 1]
+  endfor
+  call insert(bufinfo, "Select a terminal:")
+  let selection = str2nr(inputlist(bufinfo))
+
+  if selection <= 0 || selection >= len(bufinfo)
+    return
+  endif
+
+  let b:slime_config = valid_configs[selection - 1]
+endfunction
+
+
+
+
+

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -19,7 +19,7 @@ function! slime#targets#neovim#config() abort
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
     endif
-    let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_pid_string')
+    let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
 
     let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
   else
@@ -30,7 +30,7 @@ function! slime#targets#neovim#config() abort
       if !empty(default_jobid)
         let default_jobid = str2nr(default_jobid)
       endif
-      let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'custom,s:last_channel_to_jobid_string')
+      let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
       let jobid_in = str2nr(jobid_in)
     endif
     let pid_in = s:translate_id_to_pid(jobid_in)
@@ -82,7 +82,7 @@ function! slime#targets#neovim#SlimeClearChannel()
       unlet b:slime_config
     endif
   else
-    let bufinfo = s:get_filter_bufinfo()
+    let bufinfo = s:get_terminal_jobids()
 
     " tests if using a version of Neovim that
     " doesn't automatically close buffers when closed
@@ -148,7 +148,7 @@ function! slime#targets#neovim#ValidConfig(config) abort
     return 0
   endif
 
-  if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
+  if !(index(s:get_terminal_jobids(), a:config['jobid']) >= 0)
     echon "\nJob ID not found."
     return 0
   endif
@@ -169,19 +169,21 @@ endfunction
 
 " Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
 " for the purposes of input completion
-function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
+function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos)
   let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
-  return join(jobids,"\n")
+  call map(jobids, {_, val -> string(val)})
+  return jobids
 endfunction
 
 " Transforms a channel dictionary with job ida and pid into an newline separated string  of job PIDs.
 " for the purposes of input completion
-function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
-  "they will be transformed into pids so caling them by their final identity
-  let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
-  map(job_pids, {_, val -> s:translate_id_to_pid(val)})
-  call filter(job_pids, {_,val -> val != -1})
-  return join(jobpids,"\n")
+function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos)
+  "they will be transformed into pids so naming them by their final identity
+  let jobpids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
+  call map(jobpids, {_, val -> s:translate_id_to_pid(val)})
+  call filter(jobpids, {_,val -> val != -1})
+  call map(jobpids, {_, val -> string(val)})
+  return jobpids
 endfunction
 
 " Checks if a previous channel does not exist or is empty.
@@ -190,7 +192,7 @@ function! s:NotExistsLastChannel() abort
 endfunction
 
 
-function! s:get_filter_bufinfo()
+function! s:get_terminal_jobids()
   let bufinfo = getbufinfo()
   "getting terminal buffers
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -7,7 +7,7 @@ function! slime#targets#neovim#config() abort
     call s:protected_validation_and_clear(1,1)
 
     if exists("g:slime_menu_config") && g:slime_menu_config && !config_set
-      call s:config_with_menu()
+      let temp_config =  s:config_with_menu()
       let config_set = 1
     endif
 
@@ -25,20 +25,20 @@ function! slime#targets#neovim#config() abort
       let last_pid = get(most_recent_channel, 'pid', '')
       let last_job = get(most_recent_channel, 'jobid', '')
 
-      let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
+      let temp_config =  {"jobid":  last_job, "pid": last_pid }
     endif
 
     " include option to input pid
     if exists("g:slime_input_pid") && g:slime_input_pid && !config_set
-      let default_pid = slime_suggest_default ? s:translate_id_to_pid(b:slime_config["jobid"]) : ""
+      let default_pid = slime_suggest_default ? s:translate_id_to_pid(temp_config["jobid"]) : ""
       if default_pid == -1
         let default_pid = ""
       endif
       let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
       redraw
       let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
-      let b:slime_config["jobid"] = jobid_in
-      let b:slime_config["pid"] = pid_in
+      let temp_config["jobid"] = jobid_in
+      let temp_config["pid"] = pid_in
       let config_set = 1
     endif
 
@@ -46,14 +46,14 @@ function! slime#targets#neovim#config() abort
     if exists("g:slime_get_jobid") && !config_set
       let jobid_in = g:slime_get_jobid()
       let pid_in = s:translate_id_to_pid(jobid_in)
-      let b:slime_config["jobid"] = jobid_in
-      let b:slime_config["pid"] = pid_in
+      let temp_config["jobid"] = jobid_in
+      let temp_config["pid"] = pid_in
       let config_set = 1
     endif
 
     "inputing jobid
     if !config_set
-      let default_jobid = slime_suggest_default ? b:slime_config["jobid"] : ""
+      let default_jobid = slime_suggest_default ? temp_config["jobid"] : ""
       if !empty(default_jobid)
         let default_jobid = str2nr(default_jobid)
       endif
@@ -62,9 +62,11 @@ function! slime#targets#neovim#config() abort
       let jobid_in = str2nr(jobid_in)
       let pid_in = s:translate_id_to_pid(jobid_in)
 
-      let b:slime_config["jobid"] = jobid_in
-      let b:slime_config["pid"] = pid_in
+      let temp_config["jobid"] = jobid_in
+      let temp_config["pid"] = pid_in
     endif
+
+    let b:slime_config = temp_config
 
     call s:protected_validation_and_clear(0,0)
 
@@ -361,7 +363,8 @@ function! s:config_with_menu() abort
 
   let used_config = term_bufinfo[selection - 1]
 
-  let b:slime_config = {"jobid": used_config["jobid"], "pid": used_config["pid"] }
+  let config_out = {"jobid": used_config["jobid"], "pid": used_config["pid"] }
+  return config_out
 endfunction
 
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -7,7 +7,6 @@ function! slime#targets#neovim#config() abort
   endif
 
   if exists("g:slime_suggest_default") && g:slime_suggest_default
-    echom "it is 1"
     let slime_suggest_default = 1
   else
     let slime_suggest_default = 0

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -100,49 +100,49 @@ endfunction
 function! slime#targets#neovim#ValidConfig(config) abort
 
   if s:NotExistsLastChannel()
-    echon "\rTerminal not detected."
+    echon "\nTerminal not detected."
     return 0
   endif
 
   if !exists("a:config") ||  a:config is v:null
-    echon "\rConfig does not exist."
+    echon "\nConfig does not exist."
     return 0
   endif
 
   " Ensure the config is a dictionary and a previous channel exists
   if type(a:config) != v:t_dict
-    echon "\rConfig type not valid."
+    echon "\nConfig type not valid."
     return 0
   endif
 
   if empty(a:config)
-    echon "\rConfig is empty."
+    echon "\nConfig is empty."
     return 0
   endif
 
   " Ensure the correct keys exist within the configuration
   if !(has_key(a:config, 'jobid'))
-    echon "\rConfigration object lacks 'jobid'."
+    echon "\nConfigration object lacks 'jobid'."
     return 0
   endif
 
   if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
-    echon "\rNo matching job id for the provided pid."
+    echon "\nNo matching job id for the provided pid."
     return 0
   endif
 
   if !(index( s:channel_to_array(g:slime_last_channel), a:config['jobid']) >= 0)
-    echon "\rJob ID not found."
+    echon "\nJob ID not found."
     return 0
   endif
 
   if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
-    echon "\rJob ID not found."
+    echon "\nJob ID not found."
     return 0
   endif
 
   if empty(jobpid(a:config['jobid']))
-    echon "\rJob ID not linked to a PID."
+    echon "\nJob ID not linked to a PID."
     return 0
   endif
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -21,7 +21,7 @@ function! slime#targets#neovim#config() abort
       end
       let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_pid_string')
 
-      let jobid_in = s:translate_pid_to_id(pid_in)
+      let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
     else
       if exists("g:slime_get_jobid")
         let jobid_in = g:slime_get_jobid()

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -18,7 +18,7 @@ function! slime#targets#neovim#config() abort
     "validation of the environment with ValidEnv should prevent the empty string
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
-      end
+    endif
       let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_pid_string')
 
       let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
@@ -163,27 +163,27 @@ function! slime#targets#neovim#config() abort
   endfunction
 
 
-function! s:last_channel_to_jobid_array(channel_dict)
-  return map(copy(a:channel_dict), {_, val -> val["jobid"]})
-endfunction
+  function! s:last_channel_to_jobid_array(channel_dict)
+    return map(copy(a:channel_dict), {_, val -> val["jobid"]})
+  endfunction
 
-" Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
-" for teh purposes of input completion
-function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
-  "they will be transformed into pids so caling them by theier final identity
-  let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
-  return join(jobids,"\n")
-endfunction
+  " Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
+  " for teh purposes of input completion
+  function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
+    "they will be transformed into pids so caling them by theier final identity
+    let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
+    return join(jobids,"\n")
+  endfunction
 
-" Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job PIDs.
-" for the purposes of input completion
-function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
-  "they will be transformed into pids so caling them by theier final identity
-  let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
-  map(job_pids, {_, val -> s:translate_id_to_pid(val)})
-  call filter(job_pids, {_,val -> val != -1})
-  return join(jobpids,"\n")
-endfunction
+  " Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job PIDs.
+  " for the purposes of input completion
+  function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
+    "they will be transformed into pids so caling them by theier final identity
+    let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
+    map(job_pids, {_, val -> s:translate_id_to_pid(val)})
+    call filter(job_pids, {_,val -> val != -1})
+    return join(jobpids,"\n")
+  endfunction
 
   " Checks if a previous channel does not exist or is empty.
   function! s:NotExistsLastChannel() abort

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -12,13 +12,13 @@ function! slime#targets#neovim#config() abort
 
   " include option to input pid
   if exists("g:slime_input_pid") && g:slime_input_pid
-    let pid_in = input("pid: ", str2nr(jobpid(b:slime_config["jobid"])))
+    let pid_in = input("Configuring vim-slime. Input pid: ", str2nr(jobpid(b:slime_config["jobid"])))
     let id_in = s:translate_pid_to_id(pid_in)
   else
     if exists("g:slime_get_jobid")
       let id_in = g:slime_get_jobid()
     else
-      let id_in = input("jobid: ", str2nr(b:slime_config["jobid"]))
+      let id_in = input("Configuring vim-slime. Input jobid: ", str2nr(b:slime_config["jobid"]))
       let id_in = str2nr(id_in)
     endif
     let pid_in = s:translate_id_to_pid(id_in)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -6,6 +6,13 @@ function! slime#targets#neovim#config() abort
     return
   endif
 
+  if exists("g:slime_suggest_default") && g:slime_suggest_default
+    echom "it is 1"
+    let slime_suggest_default = 1
+  else
+    let slime_suggest_default = 0
+  endif
+
   " unlet current config if its jobid doesn't exist
   let last_channels = get(g:, 'slime_last_channel', [])
   let most_recent_channel = get(last_channels, -1, {})
@@ -17,8 +24,8 @@ function! slime#targets#neovim#config() abort
 
   " include option to input pid
   if exists("g:slime_input_pid") && g:slime_input_pid
-    let default_pid = s:translate_id_to_pid(b:slime_config["jobid"])
-    if default_pid != -1
+    let default_pid = slime_suggest_default ? s:translate_id_to_pid(b:slime_config["jobid"]) : ""
+    if default_pid == -1
       let default_pid = ""
     endif
     let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
@@ -37,8 +44,8 @@ function! slime#targets#neovim#config() abort
     return
   endif
 
-  "inputing pid
-  let default_jobid = b:slime_config["jobid"]
+  "inputing jobid
+  let default_jobid = slime_suggest_default ? b:slime_config["jobid"] : ""
   if !empty(default_jobid)
     let default_jobid = str2nr(default_jobid)
   endif
@@ -87,7 +94,7 @@ endfunction
 "evaluates whether ther is a terminal running; if there isn't then no config can be valid
 function! slime#targets#neovim#ValidEnv() abort
   if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
-    echon "Terminal not found."
+    echo "Terminal not found."
     return 0
   endif
   return 1

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -136,7 +136,7 @@ function! slime#targets#neovim#ValidConfig(config) abort
           \map(copy(g:slime_last_channel), {_, val -> val["jobid"]}),
           \config_in['jobid']) >= 0
           \)
-      echo "Job ID not found."
+      echo "Invalid Job ID."
       return 0
     endif
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -3,45 +3,51 @@ function! slime#targets#neovim#config() abort
 
   if exists("g:slime_menu_config") && g:slime_menu_config
     call s:config_with_menu()
-  else
-    " unlet current config if its jobid doesn't exist
-    let last_channels = get(g:, 'slime_last_channel', [])
-    let most_recent_channel = get(last_channels, -1, {})
+    return
+  endif
 
-    let last_pid = get(most_recent_channel, 'pid', '')
-    let last_job = get(most_recent_channel, 'jobid', '')
+  " unlet current config if its jobid doesn't exist
+  let last_channels = get(g:, 'slime_last_channel', [])
+  let most_recent_channel = get(last_channels, -1, {})
 
-    let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
+  let last_pid = get(most_recent_channel, 'pid', '')
+  let last_job = get(most_recent_channel, 'jobid', '')
 
-    " include option to input pid
-    if exists("g:slime_input_pid") && g:slime_input_pid
+  let b:slime_config =  {"jobid":  last_job, "pid": last_pid }
 
-      let default_pid = jobpid(b:slime_config["jobid"])
-      "if everything does right this validation should be redundant
-      "validation of the environment with ValidEnv should prevent the empty string
-      if !empty(default_pid)
-        let default_pid = str2nr(default_pid)
-      endif
-      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
-
-      let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
-    else
-      if exists("g:slime_get_jobid")
-        let jobid_in = g:slime_get_jobid()
-      else
-        let default_jobid = b:slime_config["jobid"]
-        if !empty(default_jobid)
-          let default_jobid = str2nr(default_jobid)
-        endif
-        let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
-        let jobid_in = str2nr(jobid_in)
-      endif
-      let pid_in = s:translate_id_to_pid(jobid_in)
+  " include option to input pid
+  if exists("g:slime_input_pid") && g:slime_input_pid
+    let default_pid = s:translate_id_to_pid(b:slime_config["jobid"])
+    if default_pid != -1
+      let default_pid = ""
     endif
-
+    let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
+    let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
     let b:slime_config["jobid"] = jobid_in
     let b:slime_config["pid"] = pid_in
+    return
   endif
+
+
+  if exists("g:slime_get_jobid")
+    let jobid_in = g:slime_get_jobid()
+    let pid_in = s:translate_id_to_pid(jobid_in)
+    let b:slime_config["jobid"] = jobid_in
+    let b:slime_config["pid"] = pid_in
+    return
+  endif
+
+  "inputing pid
+  let default_jobid = b:slime_config["jobid"]
+  if !empty(default_jobid)
+    let default_jobid = str2nr(default_jobid)
+  endif
+  let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
+  let jobid_in = str2nr(jobid_in)
+  let pid_in = s:translate_id_to_pid(jobid_in)
+
+  let b:slime_config["jobid"] = jobid_in
+  let b:slime_config["pid"] = pid_in
 endfunction
 
 function! slime#targets#neovim#send(config, text)
@@ -55,58 +61,32 @@ endfunction
 function! slime#targets#neovim#SlimeAddChannel(buf_in)
   let buf_in = str2nr(a:buf_in)
   let jobid = getbufvar(buf_in, "&channel")
-  let jobpid = jobpid(jobid)
+  let job_pid = jobpid(jobid)
 
   if !exists("g:slime_last_channel")
-    let g:slime_last_channel = [{'jobid': jobid, 'pid': jobpid}]
+    let g:slime_last_channel = [{'jobid': jobid, 'pid': job_pid, 'bufnr': buf_in}]
   else
-    call add(g:slime_last_channel, {'jobid': jobid, 'pid': jobpid})
+    call add(g:slime_last_channel, {'jobid': jobid, 'pid': job_pid, 'bufnr': buf_in})
   endif
 endfunction
 
 function! slime#targets#neovim#SlimeClearChannel(buf_in)
-
-  let bufinfo = getbufinfo()
-
   if !exists("g:slime_last_channel")
     call s:clear_all_buffs()
     return
   elseif len(g:slime_last_channel) <= 1
     call s:clear_all_buffs()
-    let g:slime_last_channel = []
+    unlet g:slime_last_channel
   else
-    echom "len slime last greater than one"
-    let buf_in = str2nr(a:buf_in)
-    "filtering for the buffer info with the terminal job
-    let target_buffer =  filter(copy(bufinfo), {_, val -> val['bufnr'] == buf_in})
-
-    if len(target_buffer) == 1
-      " getbufinfo was able to detect the terminal buffer
-      let jobid = getbufvar(buf_in, "&channel")
-      if jobid == ""
-        " the buffer somehow go wiped out
-        let jobid = s:job_id_when_buffer_cleared()
-      endif
-    else
-      let jobid = s:job_id_when_buffer_cleared()
-    endif
-    call s:clear_related_bufs(jobid)
-    call filter(g:slime_last_channel, {_, val -> str2nr(val['jobid']) != jobid})
+    let jobid_to_clear = filter(copy(g:slime_last_channel), {_, val -> val['bufnr'] == a:buf_in})[0]['jobid']
+    call s:clear_related_bufs(jobid_to_clear)
+    call filter(g:slime_last_channel, {_, val -> val['bufnr'] != a:buf_in})
   endif
 endfunction
 
-function! s:job_id_when_buffer_cleared()
-  let listed_term_jobs = s:get_terminal_jobids()
-  let last_term_jobs =  map(copy(g:slime_last_channel),{_, val -> val['jobid']})
-  call filter(last_term_jobs, {_, val -> index(listed_term_jobs, val) == -1})
-  let jobid = last_term_jobs[0]
-  return jobid
-endfunction
-
-
 "evaluates whether ther is a terminal running; if there isn't then no config can be valid
 function! slime#targets#neovim#ValidEnv() abort
-  if s:NotExistsLastChannel()
+  if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
     echon "Terminal not found."
     return 0
   endif
@@ -116,19 +96,15 @@ endfunction
 " "checks that a configuration is valid
 " returns boolean of whether the supplied config is valid
 function! slime#targets#neovim#ValidConfig(config) abort
+  "config is passed as a string, the name of the config variable
   if !exists(a:config)
     echo "\nNo config found."
     return 0
   else
     let config_in = eval(a:config)
 
-    if s:NotExistsLastChannel()
+    if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
       echo "Terminal not found."
-      return 0
-    endif
-
-    if !exists("config_in") ||  config_in is v:null
-      echo "Config does not exist."
       return 0
     endif
 
@@ -154,17 +130,15 @@ function! slime#targets#neovim#ValidConfig(config) abort
       return 0
     endif
 
-    if !(index( s:last_channel_to_jobid_array(g:slime_last_channel), config_in['jobid']) >= 0)
+    if !(index(
+          \map(copy(g:slime_last_channel), {_, val -> val["jobid"]}),
+          \config_in['jobid']) >= 0
+          \)
       echo "Job ID not found."
       return 0
     endif
 
-    if !(index(s:get_terminal_jobids(), config_in['jobid']) >= 0)
-      echo "Job ID not found."
-      return 0
-    endif
-
-    if empty(jobpid(config_in['jobid']))
+    if s:translate_id_to_pid(config_in['jobid'])
       echo "Job ID not linked to a PID."
       return 0
     endif
@@ -173,7 +147,6 @@ function! slime#targets#neovim#ValidConfig(config) abort
 
   return 1
 endfunction
-
 
 function! s:translate_pid_to_id(pid)
   for ch in g:slime_last_channel
@@ -188,48 +161,15 @@ function! s:translate_id_to_pid(id)
   let pid_out = -1
   try
     let pid_out = jobpid(a:id)
-  catch /E900: Invalid channel id/
+  catch
   endtry
   return pid_out
 endfunction
 
-
-" Checks if a previous channel does not exist or is empty.
-function! s:NotExistsLastChannel() abort
-  return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
-endfunction
-
-function! s:get_terminal_jobids()
-  "transforming it so calling it by its final form
-  let job_ids = getbufinfo()
-  call filter(job_ids, {_, val -> get(val, "listed", 0)})
-  call map(job_ids, {_, val -> val['bufnr']})
-  call map(job_ids, {_, val -> getbufvar(val, '&channel')})
-  call filter(job_ids, {_, val -> val > 0})
-  return job_ids
-endfunction
-
-function! s:get_terminal_bufinfo()
-  "get full bufinfo only of terminal buffers
-  let buf_info = getbufinfo()
-  call filter(buf_info, {_, val -> get(val, "listed", 0)})
-  let buf_nrs =  map(copy( buf_info ), {_, val -> val['bufnr']})
-  let job_ids =  map(copy(buf_nrs), {_, val -> getbufvar(val, '&channel')})
-  for i in range(len(job_ids) - 1)
-    if job_ids[i] == 0
-      let buf_info[i] = 0
-    endif
-  endfor
-
-  call filter(buf_info, {_, val -> type(val) == v:t_dict})
-  return buf_info
-endfunction
-
-
 " Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
 " for the purposes of input completion
 function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos)
-  let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
+  let jobids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
   call map(jobids, {_, val -> string(val)})
   return jobids
 endfunction
@@ -243,12 +183,6 @@ function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos)
   call filter(jobpids, {_,val -> val != -1})
   call map(jobpids, {_, val -> string(val)})
   return jobpids
-endfunction
-
-
-
-function! s:last_channel_to_jobid_array(channel_dict)
-  return map(copy(a:channel_dict), {_, val -> val["jobid"]})
 endfunction
 
 
@@ -271,25 +205,31 @@ function! s:clear_all_buffs()
   endfor
 endfunction
 
-function! s:extract_buffer_details(buffer)
-  let bufnr = get(a:buffer, 'bufnr', -3)
-  let details = {}
-  let details['name'] = get(a:buffer, 'name', 'N/A')
-  let vars = get(a:buffer, 'variables', {})
-  let details['term_title'] = get(vars, 'term_title', 'N/A')
+function! s:extend_term_buffer_titles(specific_term_info, all_bufinfo)
+  " add buffer name and terminal title to a dictionary that already has jobid, pid, buffer number
+  "specific term info is a dictionary that contains jobid, pid, and bufnr
+  " all_bufinfo is the output of getbufinfo()
 
-  if bufnr != -3
-    let details['jobid'] = getbufvar(bufnr, '&channel', 0)
-  endif
-  return details
+  " important to use copy here to avoid filtering in calling environment
+  let all_bufinfo_in = copy(all_bufinfo)
+  let specific_term_info_in = copy(specific_term_info)
+
+  " get the term info
+  let wanted_term = filter(all_bufinfo_in, {_, val -> val['bufnr'] == specific_term_info_in['bufnr']})[0]
+  return extend(specific_term_info_in, {'name': wanted_term['name'], 'term_title': wanted_term['variables']['term_title']})
 endfunction
 
 
 function! s:buffer_dictionary_to_string(dict_in)
+  " dict in is an array of dictionaries that has the values of the menu items
+
+  "menu order is an array of dictionaries
+  "menu entries will follow the order of menu order
+  " the labels of each field of the menu entry will be the values of each dictionary in the array
   if exists('g:slime_neovim_menu_order')
     let menu_order = g:slime_neovim_menu_order
   else
-    let menu_order = [{'pid': 'pid: '},{'jobid':'jobid: '},{'term_title':''},{'name':''}]
+    let menu_order = [{'pid': 'pid: '}, {'jobid': 'jobid: '}, {'term_title':''}, {'name': ''}]
   endif
 
   if exists('g:slime_neovim_menu_delimiter')
@@ -302,7 +242,7 @@ function! s:buffer_dictionary_to_string(dict_in)
 
   for i in range(len(menu_order))
     let menu_item = menu_order[i]
-    let key = keys(menu_order[i])[0]
+    let key = keys(menu_item)[0]
     let label = get(menu_item, key, "")
     let value = get(a:dict_in, key, "")
     if i != len(menu_order) - 1
@@ -315,26 +255,40 @@ function! s:buffer_dictionary_to_string(dict_in)
   return menu_string
 endfunction
 
-function! s:config_with_menu()
-  let bufinfo = s:get_terminal_bufinfo()
-  call map(bufinfo, { _, val -> s:extract_buffer_details(val)})
-  let valid_job_ids = s:last_channel_to_jobid_array(g:slime_last_channel)
-  call filter(bufinfo, {_, val -> index( valid_job_ids, val['jobid']) >= 0})
-  call map(bufinfo, {_, val -> extend(val, {'pid': s:translate_id_to_pid(val['jobid'])})})
-  call filter(bufinfo, {_, val ->  val['pid'] != -1})
-  let valid_configs =  map(copy(bufinfo), {_, val ->  {'jobid': val['jobid'], 'pid': val['pid']}})
-  call map(bufinfo, {_, val -> s:buffer_dictionary_to_string(val)})
-  for i in range(1, len(bufinfo))
-    let bufinfo[i - 1] = i . '. ' . bufinfo[i - 1]
-  endfor
-  call insert(bufinfo, "Select a terminal:")
-  let selection = str2nr(inputlist(bufinfo))
 
-  if selection <= 0 || selection >= len(bufinfo)
+"get full bufinfo only of terminal buffers
+function! s:get_terminal_bufinfo()
+  if !exists("g:slime_last_channel") || len(g:slime_last_channel) == 0 || empty(g:slime_last_channel)
+    "there are no valid terminal buffers
+    return []
+  endif
+
+  let buf_info = getbufinfo()
+  return map(copy(g:slime_last_channel), { _, val -> s:extend_term_buffer_titles(val, buf_info)})
+endfunction
+
+
+function! s:config_with_menu()
+  " get info of running terminals, array of dictionaries
+  let term_bufinfo = s:get_terminal_bufinfo()
+
+  " turn each item into a string for the menu
+  let menu_strings =  map(copy(term_bufinfo), {_, val -> s:buffer_dictionary_to_string(val)})
+
+  for i in range(1, len(menu_strings))
+    let menu_strings[i - 1] = i . '. ' . menu_strings[i - 1]
+  endfor
+  call insert(menu_strings, "Select a terminal:")
+
+  let selection = str2nr(inputlist(menu_strings))
+
+  if selection <= 0 || selection >= len(term_bufinfo)
     return
   endif
 
-  let b:slime_config = valid_configs[selection - 1]
+  let used_config = term_bufinfo[selection]
+
+  let b:slime_config = {"jobid": used_config["jobid"], "pid": term_bufinfo["pid"], }
 endfunction
 
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -140,14 +140,14 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
 
 
   " Ensure the config is a dictionary and a previous channel exists
-  if type(config_in) != v:t_dict
+  if type(a:config) != v:t_dict
     if !a:silent
       echo "Config type not valid."
     endif
     return 0
   endif
 
-  if empty(config_in)
+  if empty(a:config)
     if !a:silent
       echo "Config is empty."
     endif
@@ -155,14 +155,14 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
   endif
 
   " Ensure the correct keys exist within the configuration
-  if !(has_key(config_in, 'jobid'))
+  if !(has_key(a:config, 'jobid'))
     if !a:silent
       echo "Configration object lacks 'jobid'."
     endif
     return 0
   endif
 
-  if config_in["jobid"] == -1  "the id wasn't found translate_pid_to_id
+  if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
     if !a:silent
       echo "No matching job id for the provided pid."
     endif
@@ -171,7 +171,7 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
 
   if !(index(
         \map(copy(g:slime_last_channel), {_, val -> val["jobid"]}),
-        \config_in['jobid']) >= 0
+        \a:config['jobid']) >= 0
         \)
     if !a:silent
       echo "Invalid Job ID."
@@ -179,7 +179,7 @@ function! slime#targets#neovim#ValidConfig(config, silent) abort
     return 0
   endif
 
-  if s:translate_id_to_pid(config_in['jobid']) == -1
+  if s:translate_id_to_pid(a:config['jobid']) == -1
     if !a:silent
       echo "Job ID not linked to a PID."
     endif

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -98,11 +98,11 @@ function! slime#targets#neovim#SlimeClearChannel(buf_in)
 endfunction
 
 function! s:job_id_when_buffer_cleared()
-      let listed_term_jobs = s:get_terminal_jobids()
-      let last_term_jobs =  map(copy(g:slime_last_channel),{_, val -> val['jobid']})
-      call filter(last_term_jobs, {_, val -> index(listed_term_jobs, val) == -1})
-      let jobid = last_term_jobs[0]
-      return jobid
+  let listed_term_jobs = s:get_terminal_jobids()
+  let last_term_jobs =  map(copy(g:slime_last_channel),{_, val -> val['jobid']})
+  call filter(last_term_jobs, {_, val -> index(listed_term_jobs, val) == -1})
+  let jobid = last_term_jobs[0]
+  return jobid
 endfunction
 
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -163,27 +163,29 @@ function! slime#targets#neovim#config() abort
   endfunction
 
 
-  " Transforms a channel dictionary with job ida and pid into an array of job IDs.
-  function! s:last_channel_to_jobid_array(channel_dict)
-    return map(copy(a:channel_dict), {_, val -> val["jobid"]})
-  endfunction
+function! s:last_channel_to_jobid_array(channel_dict)
+  return map(copy(a:channel_dict), {_, val -> val["jobid"]})
+endfunction
 
-  function! s:last_channel_to_jobid_string(channel_dict)
-    "they will be transformed into pids so caling them by theier final identity
-    let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
-    return join(jobids,"\n")
+" Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
+" for teh purposes of input completion
+function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
+  "they will be transformed into pids so caling them by theier final identity
+  let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
+  return join(jobids,"\n")
 
-  endfunction
+endfunction
 
-  " Transforms a channel dictionary with job ida and pid into an array of job IDs.
-  function! s:last_channel_to_pid_string(channel_dict)
-    "they will be transformed into pids so caling them by theier final identity
-    let job_pids = map(copy(a:channel_dict), {_, val -> val["jobid"]})
-     map(job_pids, {_, val -> s:translate_id_to_pid(val)})
-    call filter(job_pids, {_,val -> val != -1})
-    return join(jobpids,"\n")
+" Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job PIDs.
+" for the purposes of input completion
+function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
+  "they will be transformed into pids so caling them by theier final identity
+  let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
+  map(job_pids, {_, val -> s:translate_id_to_pid(val)})
+  call filter(job_pids, {_,val -> val != -1})
+  return join(jobpids,"\n")
 
-  endfunction
+endfunction
 
   " Checks if a previous channel does not exist or is empty.
   function! s:NotExistsLastChannel() abort

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -97,10 +97,12 @@ endfunction
 " returns boolean of whether the supplied config is valid
 function! slime#targets#neovim#ValidConfig(config) abort
   "config is passed as a string, the name of the config variable
+
   if !exists(a:config)
-    echo "\nNo config found."
+    echo "No config found."
     return 0
   else
+
     let config_in = eval(a:config)
 
     if (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1) || empty(g:slime_last_channel)
@@ -138,7 +140,7 @@ function! slime#targets#neovim#ValidConfig(config) abort
       return 0
     endif
 
-    if s:translate_id_to_pid(config_in['jobid'])
+    if s:translate_id_to_pid(config_in['jobid']) == -1
       echo "Job ID not linked to a PID."
       return 0
     endif
@@ -171,7 +173,7 @@ endfunction
 function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos) abort
   let jobids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
   call map(jobids, {_, val -> string(val)})
-  return jobids
+  return reverse(jobids) " making correct order in menu
 endfunction
 
 " Transforms a channel dictionary with job ida and pid into an newline separated string  of job PIDs.
@@ -182,7 +184,7 @@ function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos) abort
   call map(jobpids, {_, val -> s:translate_id_to_pid(val)})
   call filter(jobpids, {_,val -> val != -1})
   call map(jobpids, {_, val -> string(val)})
-  return jobpids
+  return reverse(jobpids) "making most recent the first selected
 endfunction
 
 
@@ -270,7 +272,8 @@ endfunction
 
 function! s:config_with_menu() abort
   " get info of running terminals, array of dictionaries
-  let term_bufinfo = s:get_terminal_bufinfo()
+  " reversing to make it appear in the right order in the menu
+  let term_bufinfo =  s:get_terminal_bufinfo()
 
   " turn each item into a string for the menu
   let menu_strings =  map(copy(term_bufinfo), {_, val -> s:buffer_dictionary_to_string(val)})
@@ -282,13 +285,13 @@ function! s:config_with_menu() abort
 
   let selection = str2nr(inputlist(menu_strings))
 
-  if selection <= 0 || selection >= len(term_bufinfo)
+  if selection <= 0 || selection >= len(menu_strings)
     return
   endif
 
-  let used_config = term_bufinfo[selection]
+  let used_config = term_bufinfo[selection - 1]
 
-  let b:slime_config = {"jobid": used_config["jobid"], "pid": term_bufinfo["pid"], }
+  let b:slime_config = {"jobid": used_config["jobid"], "pid": used_config["pid"] }
 endfunction
 
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -144,7 +144,7 @@ function! slime#targets#neovim#ValidEnv() abort
     echohl none
     return 0
   endif
-    echohl none
+  echohl none
   return 1
 endfunction
 
@@ -238,7 +238,7 @@ function! s:translate_id_to_pid(id) abort
   return pid_out
 endfunction
 
-" Transforms a channel dictionary with job ID and pid into an newline separated string  of job IDs.
+" Transforms a channel dictionary with job ID and pid into a newline separated string  of job IDs.
 " for the purposes of input completion
 function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos) abort
   let jobids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -300,8 +300,3 @@ function! s:config_with_menu() abort
 
   let b:slime_config = {"jobid": used_config["jobid"], "pid": used_config["pid"] }
 endfunction
-
-
-
-
-

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -47,28 +47,6 @@ if slime#config#resolve("target") == "neovim"
       " keeping track when terminals are closed
       autocmd TermClose * call slime#targets#neovim#SlimeClearChannel(expand('<abuf>'))
     augroup END
-
-
-    " setting default configuraiton falues for neovim
-    " could put the remainder of the code in this block into autoload/slime/config.vim
-    " if true use a prompted menu config to 
-    let g:slime_config_defaults["menu_config"] = 0
-
-    " whether to populate the command line with an identifier when configuring
-    let g:slime_config_defaults["suggest_default"] = 1
-
-    "input PID rather than job ID on the command line when configuring
-    let g:slime_config_defaults["input_pid"] = 0
-
-    " can be set to a user-defined function to automatically get a job ID. Set as zero here to evaluate to false.
-    let g:slime_config_defaults["get_jobid"] = 0
-
-    "order of menu if configuring that way
-    let g:slime_config_defaults["neovim_menu_order"] = [{'pid': 'pid: '}, {'jobid': 'jobid: '}, {'term_title':''}, {'name': ''}]
-
-    "delimiter of menu if configuring that way
-    let g:slime_config_defaults["neovim_menu_delimiter"] = ','
-
   else
     call slime#targets#neovim#EchoWarningMsg("Trying to use Neovim target in standard Vim. This won't work.")
   endif

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -39,11 +39,37 @@ endif
 " for neovim (only), make slime_last_channel contain
 " the channel id of the last opened terminal
 if slime#config#resolve("target") == "neovim"
-  augroup nvim_slime
-    autocmd!
-    " keeping track of channels that are open
-    autocmd TermOpen * call slime#targets#neovim#SlimeAddChannel(expand('<abuf>'))
-    " keeping track when terminals are closed
-    autocmd TermClose * call slime#targets#neovim#SlimeClearChannel(expand('<abuf>'))
-  augroup END
+  if has('nvim')
+    augroup nvim_slime
+      autocmd!
+      " keeping track of channels that are open
+      autocmd TermOpen * call slime#targets#neovim#SlimeAddChannel(expand('<abuf>'))
+      " keeping track when terminals are closed
+      autocmd TermClose * call slime#targets#neovim#SlimeClearChannel(expand('<abuf>'))
+    augroup END
+
+
+    " setting default configuraiton falues for neovim
+    " could put the remainder of the code in this block into autoload/slime/config.vim
+    " if true use a prompted menu config to 
+    let g:slime_config_defaults["menu_config"] = 0
+
+    " whether to populate the command line with an identifier when configuring
+    let g:slime_config_defaults["suggest_default"] = 1
+
+    "input PID rather than job ID on the command line when configuring
+    let g:slime_config_defaults["input_pid"] = 0
+
+    " can be set to a user-defined function to automatically get a job ID. Set as zero here to evaluate to false.
+    let g:slime_config_defaults["get_jobid"] = 0
+
+    "order of menu if configuring that way
+    let g:slime_config_defaults["neovim_menu_order"] = [{'pid': 'pid: '}, {'jobid': 'jobid: '}, {'term_title':''}, {'name': ''}]
+
+    "delimiter of menu if configuring that way
+    let g:slime_config_defaults["neovim_menu_delimiter"] = ','
+
+  else
+    call slime#targets#neovim#EchoWarningMsg("Trying to use Neovim target in standard Vim. This won't work.")
+  endif
 endif

--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -42,8 +42,8 @@ if slime#config#resolve("target") == "neovim"
   augroup nvim_slime
     autocmd!
     " keeping track of channels that are open
-    autocmd TermOpen * call slime#targets#neovim#SlimeAddChannel()
+    autocmd TermOpen * call slime#targets#neovim#SlimeAddChannel(expand('<abuf>'))
     " keeping track when terminals are closed
-    autocmd TermClose * call slime#targets#neovim#SlimeClearChannel()
+    autocmd TermClose * call slime#targets#neovim#SlimeClearChannel(expand('<abuf>'))
   augroup END
 endif


### PR DESCRIPTION
In my [recent issue](https://github.com/jpalardy/vim-slime/issues/417) I proposed changes to `autoload/slime.vim`.  You suggested a more conservative approach.  The two approaches are summarized in this image:
![image](https://github.com/jpalardy/vim-slime/assets/2414185/0491a8b9-fb04-4fa1-b553-c15b85593663)
With your preferred way on the left, and what I suggested on the right, with your annotations overlaid.

I said I'd open two pull requests, one with your preferred way and one with my preferred way.  Instead I'm just opening this one, which is your preferred way; the changes to the Neovim target code are quite extensive (in a way that I feel is justified) so it will be easier to try to get this merged first, because the changes here are already quite extensive.

I know that this makes the Neovim target the one with the most code by far, but I think what I have here enhances the user experience overall. Give it a try/compare it to how it was before to sew why I made it this way.

Here is an explanation of the changes:

## `README.md`

A small change to phrasing.

## `plugin/slime.vim`


`slime#targets#neovim#SlimeAddChannel(expand('<abuf>'))` and `slime#targets#neovim#SlimeClearChannel(expand('<abuf>'))` use `<abuf>` now to track exactly the buffers being acted on regardless of whether they are active.  I didn't know about this feature before and it allowed me to simplify these channel tracking functions/not have to deal with corner cases.

## `autoload/slime.vim`

- Made a small change here, adding a a check that the config is not empty.  In this case it helpe to make sure the user is prompted for a config when there is an attempt to send text the current config is empty.  This is a very light version of my ultimate desired changes, which will catch more cases. 

- Removed redundant calls to `GetConfig`. With them in, we are sometimes prompted to configure twice if we mmisconfigure the first time.

## `assets/doc/targets/neovim.md`

A full explanation of the features I added to `autoload/slime.vim` (read it to see everything I have added).  This is a lot but I commit to maintaining it.

The goal here is to give very clear documentation so that someone with late-beginner vim knowledge can get started more easily.

I found that these changes were difficult to implement using overrides, hence this PR.




## `autoload/slime/targets/neovim.vim`

Here are the big changes.

Calls to my validation functions are added by way of `s:protected_validation_and_clear` which checks for existence of a buffer's config, and then makes sure that it is correct. If the config is not valid, all identical configs in other buffers are cleared.

### `slime#targets#neovim#config()`

Wrapped in a call that checks for a valid environment.

Changed to allow config with a menu prompt or direct entry on the command line (configurable as detailed in the Neovim documentation).

Still allows users to enter `pid` or `jobid`.

I uset the `temp_config` variable so that any status line customization doesn't show any intermediate value of the config.



### `slime#targets#neovim#send`

Wrapped into a a call to the validation function.

If the config is not valid, it is cleared, and all similar configs are cleared from other buffers.


### `SlimeAddChannel` and `SlimeClearChannel`

Keep a master list of open terminals.

These functions are greatly simplified from where they were before, because of the use of `<abuf>` in the autocommands that call them.


### `ValidEnv`

Checks if the environment  is valid. Basically means if there is an open terminal or not.

### `ValidConfig`

Checks if a config is valid.  Has an option to be silent.




### `Last_channel_to_jobid` and `Last_channel_to_pid`

Are menu completion functions for the calls to `input` in the configuration function.


### `clear_related_bufs` and `clear_all_bufs`

Clear specified, or all, configs from all open buffers.

### `config_with_menu` and `buffer_dictionary_to_string` 

Provide menu based configuration rather than direct input.

# Future Improvements

If you accept this, my further desired changes to `autoload/slime.vim` will allow this code to be simplified quite a bit.

Right now are also some double warning messages, and corner cases where you are prompted to config twice if you misconfigure the first time, and these are also fixed by my modifications to `autoload/slime.vim`  and other files that I have in another branch.

