### PR TITLE
Fix "Terminal not found." when using together with `akinsho/toggleter…

### DIFF
--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -112,7 +112,7 @@ endfunction
 function! slime#targets#neovim#SlimeAddChannel(buf_in) abort
   let buf_in = str2nr(a:buf_in)
   " check if the buffer is a terminal and not hidden
-  if !buflisted(buf_in) || getbufvar(buf_in, "&buftype") != "terminal"
+  if getbufvar(buf_in, "&buftype") != "terminal"
     return
   endif
 


### PR DESCRIPTION
Fix "Terminal not found." when using together with `akinsho/toggleterm.nvim`

`akinsho/toggleterm.nvim` will not list its terminal in buffer list.
And it will return directly in this if
So it will results in that the toggleterm.nvim's terminal will not be added. 