### PR TITLE
Bug fixes

### DIFF
--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -62,6 +62,7 @@ let g:slime_neovim_menu_delimiter = ' | '
 
 No validation is performed on these customization values so be sure they are properly set.
 
+You might set both `g:slime_suggest_default = 0` and `g:slime_menu_config = 0` in cases where other plugins create terminal that you would never want to send text to.
 
 ## Terminal Process Identification
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -62,7 +62,7 @@ let g:slime_neovim_menu_delimiter = ' | '
 
 No validation is performed on these customization values so be sure they are properly set.
 
-You might set both `g:slime_suggest_default = 0` and `g:slime_menu_config = 0` in cases where other plugins create terminal that you would never want to send text to.
+You might set both `g:slime_suggest_default = 0` and `g:slime_menu_config = 0` in cases where other plugins create terminals that you would never want to send text to.
 
 ## Terminal Process Identification
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -128,15 +128,12 @@ endfunction
 
 function! slime#targets#neovim#SlimeClearChannel(buf_in) abort
   if !exists("g:slime_last_channel")
-    echom "slc doesn't exist"
     call s:clear_all_buffs()
     return
   elseif len(g:slime_last_channel) == 0
-    echom "slc len == 0"
     call s:clear_all_buffs()
     unlet g:slime_last_channel
   else
-    echom "slc longer"
     let last_channel_copy =  copy(g:slime_last_channel)
     let filtered_last_channels = filter(last_channel_copy, {_, val -> val['bufnr'] == a:buf_in})
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -32,7 +32,7 @@ function! slime#targets#neovim#config() abort
         let default_pid = ""
       endif
       let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
-      redraw
+      "redraw
       let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
       let temp_config["jobid"] = jobid_in
       let temp_config["pid"] = pid_in
@@ -55,7 +55,7 @@ function! slime#targets#neovim#config() abort
         let default_jobid = str2nr(default_jobid)
       endif
       let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
-      redraw
+      "redraw
       let jobid_in = str2nr(jobid_in)
       let pid_in = s:translate_id_to_pid(jobid_in)
 
@@ -128,15 +128,24 @@ endfunction
 
 function! slime#targets#neovim#SlimeClearChannel(buf_in) abort
   if !exists("g:slime_last_channel")
+    echom "slc doesn't exist"
     call s:clear_all_buffs()
     return
-  elseif len(g:slime_last_channel) <= 1
+  elseif len(g:slime_last_channel) == 0
+    echom "slc len == 0"
     call s:clear_all_buffs()
     unlet g:slime_last_channel
   else
-    let jobid_to_clear = filter(copy(g:slime_last_channel), {_, val -> val['bufnr'] == a:buf_in})[0]['jobid']
-    call s:clear_related_bufs(jobid_to_clear)
-    call filter(g:slime_last_channel, {_, val -> val['bufnr'] != a:buf_in})
+    echom "slc longer"
+    let last_channel_copy =  copy(g:slime_last_channel)
+    let filtered_last_channels = filter(last_channel_copy, {_, val -> val['bufnr'] == a:buf_in})
+
+    if len(filtered_last_channels) > 0
+      let jobid_to_clear = filtered_last_channels[0]['jobid']
+      call s:clear_related_bufs(jobid_to_clear)
+      call filter(g:slime_last_channel, {_, val -> val['bufnr'] != a:buf_in})
+    endif
+
   endif
 endfunction
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -32,7 +32,7 @@ function! slime#targets#neovim#config() abort
         let default_pid = ""
       endif
       let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
-      "redraw
+      redraw
       let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
       let temp_config["jobid"] = jobid_in
       let temp_config["pid"] = pid_in
@@ -55,7 +55,7 @@ function! slime#targets#neovim#config() abort
         let default_jobid = str2nr(default_jobid)
       endif
       let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
-      "redraw
+      redraw
       let jobid_in = str2nr(jobid_in)
       let pid_in = s:translate_id_to_pid(jobid_in)
 


### PR DESCRIPTION
Further address issue #420 and pr #421.  Makes `SlimeClearChannel` more robust against cases where the terminal being closes isn't listed, and not included in `g:slime_last_channel`.

As I said before, will look at  pr #422 very soon. 