### PR TITLE
Better dealing with hidden and non-interactive terminals

### DIFF
--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -217,6 +217,10 @@ This is not possible or straightforward to do in pure vimscript due to capitaliz
     vim.g.slime_input_pid = false
     vim.g.slime_suggest_default = true
     vim.g.slime_menu_config = false
+    vim.g.slime_neovim_ignore_unlisted = false
+    -- options not set here are g:slime_neovim_menu_order, g:slime_neovim_menu_delimiter, and g:slime_get_jobid
+    -- see the documentation above to learn about those options
+
     -- called MotionSend but works with textobjects as well
     vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
     vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -62,7 +62,11 @@ let g:slime_neovim_menu_delimiter = ' | '
 
 No validation is performed on these customization values so be sure they are properly set.
 
-You might set both `g:slime_suggest_default = 0` and `g:slime_menu_config = 0` in cases where other plugins create terminals that you would never want to send text to.
+## Unlisted Terminals
+
+By default Slime can send send text to unlisted terminals (such as those created by [toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim).
+
+To disable this capability, and prevent unisted terminals from being shown in menu configuration and from being suggested as a default set `g:slime_neovim_ignore_unlisted = 1` (or to any other logically true value). Setting `g:slime_neovim_ignore_unlisted = 0` preserves the default of being able to send to unlisted terminals.
 
 ## Terminal Process Identification
 

--- a/autoload/slime/config.vim
+++ b/autoload/slime/config.vim
@@ -43,6 +43,9 @@ if slime#config#resolve("target") == "neovim"
     "delimiter of menu if configuring that way
     let g:slime_config_defaults["neovim_menu_delimiter"] = ', '
 
+    "if set to to a true value, will disable ability to send to unlisted buffers
+    let g:slime_config_defaults["neovim_ignore_unlisted"] = 0
+
   else
     call slime#targets#neovim#EchoWarningMsg("Trying to use Neovim target in standard Vim. This won't work.")
   endif

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -116,8 +116,8 @@ function! slime#targets#neovim#SlimeAddChannel(buf_in) abort
     return
   endif
 
-  " only interactive terminals havve the &channel option
-  " this is counterintuitive and poorly documented
+  " only interactive terminals havve the &channel option, it is one of their defining properties
+  " this is poorly documented
   " getbufvar returns "" when the option/variable lit looks for isn't found
   let jobid = getbufvar(buf_in, "&channel")
   if jobid == ""

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -111,12 +111,19 @@ endfunction
 
 function! slime#targets#neovim#SlimeAddChannel(buf_in) abort
   let buf_in = str2nr(a:buf_in)
-  " check if the buffer is a terminal and not hidden
-  if !buflisted(buf_in) || getbufvar(buf_in, "&buftype") != "terminal"
+
+  if slime#config#resolve("neovim_ignore_unlisted") && !buflisted(buf_in)
     return
   endif
 
+  " only interactive terminals havve the &channel option
+  " this is counterintuitive and poorly documented
+  " getbufvar returns "" when the option/variable lit looks for isn't found
   let jobid = getbufvar(buf_in, "&channel")
+  if jobid == ""
+    return
+  endif
+
   let job_pid = jobpid(jobid)
 
   if !exists("g:slime_last_channel")


### PR DESCRIPTION
Over the past two days  issue #420, pr #421, and  pr #422 dealt with how the Neovim target handles non-interactive terminals, and unlisted terminals.

But pr #421 and #422 are in conflict with each other. I aimed to fix the problems that those PRs addressed and resolve the conflict between them by creating an additional user-configurable option.

This PR:

- adds a check in `SlimeAddChannel` to make sure that a terminal that is opened has the `&channel` setting, which is what determines if it is a valid target.  I did a quick test with [neotest](https://github.com/nvim-neotest/neotest) and as mentioned in issue #420 , following the example tests in [this tutorial](https://semaphoreci.com/community/tutorials/testing-python-applications-with-pytest), and an error as described came up when this change wasn't added, and was fixed when it was.

- adds a configurable option , `g:slime_neovim_ignore_unlisted` that turns on or off unlisted buffers being available as targets. This addresses PR #422 

- adds documentation of these changes
