### PR TITLE
addresses issue #427

### DIFF
--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -105,7 +105,7 @@ function! slime#targets#neovim#send(config, text) abort
     call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
   elseif exists("b:slime_config") " using exists instead of resolve here because slime_config is explicitly called as b:slime_config in the base send function
       call s:sure_clear_buf_config()
-      unlet b:slime_config
+      let b:slime_config = {}
   endif
 endfunction
 


### PR DESCRIPTION
Issue #427 shows that ugly error messasges appear for certain filetype plugins  if they break the text into multiple chunks, and the config is already not valid, for the neovim target.  This was caused by the Neovim send function unletting invalid configs.  To fix it, it now just sets the config to an empty dictionary. 

