### PR TITLE
Fix chunk paste_file

### DIFF
--- a/autoload/slime/common.vim
+++ b/autoload/slime/common.vim
@@ -24,8 +24,8 @@ function! slime#common#write_paste_file(text)
   if !isdirectory(paste_dir)
     call mkdir(paste_dir, "p")
   endif
-  let lines = slime#common#lines(a:text)
-  call writefile(lines, slime#config#resolve("paste_file"))
+  let lines = split(a:text, "\n", 1)
+  call writefile(lines, slime#config#resolve("paste_file"), 'b')
 endfunction
 
 function! slime#common#capitalize(text)


### PR DESCRIPTION
previously
- [split()](https://vimhelp.org/builtin.txt.html#split%28%29) (through `slime#common#lines`) did not have `keepempty` semantics 😬  — so, the empty lines at the beginning and end were trimmed out
- meanwhile, [writefile()](https://vimhelp.org/builtin.txt.html#writefile%28%29) automatically adds a newline to the file, which isn't always what's needed (e.g. tmux chunks)

now
- closer to "what-you-send-is-what-you-get"
- `slime#common` doesn't second-guess the newline intent
- the builtin functions have a lot of sharp edges…

tests
- longer than 1000 characters pastes w/ tmux (doesn't add/remove newlines)
- `SlimeSend0` doesn't add a newline