### PR TITLE
Rework tmux target

### DIFF
--- a/assets/doc/targets/tmux.md
+++ b/assets/doc/targets/tmux.md
@@ -7,19 +7,6 @@
 let g:slime_target = "tmux"
 ```
 
-Before tmux 2.2, tmux accepted input from STDIN. This doesn't work anymore. To
-make it work out without explicit config, the default was changed to use a file
-like Screen. By default this file is set to `$HOME/.slime_paste`. The name of
-the file used can be configured through a variable:
-
-```vim
-let g:slime_paste_file = expand("$HOME/.slime_paste")
-" or maybe...
-let g:slime_paste_file = tempname()
-```
-
-⚠️  This file is not erased by the plugin and will always contain the last thing you sent over.
-
 When you invoke `vim-slime` for the first time, you will be prompted for more configuration.
 
 tmux socket name or absolute path:

--- a/autoload/slime/targets/tmux.vim
+++ b/autoload/slime/targets/tmux.vim
@@ -14,14 +14,15 @@ function! slime#targets#tmux#send(config, text)
   let target_cmd = s:target_cmd(a:config["socket_name"])
   let [bracketed_paste, text_to_paste, has_crlf] = slime#common#bracketed_paste(a:text)
 
+  " only need to do this once
+  call slime#common#system(target_cmd . " send-keys -X -t %s cancel", [a:config["target_pane"]])
+
   " reasonable hardcode, will become config if needed
   let chunk_size = 1000
 
   for i in range(0, len(text_to_paste) / chunk_size)
     let chunk = text_to_paste[i * chunk_size : (i + 1) * chunk_size - 1]
-    call slime#common#write_paste_file(chunk)
-    call slime#common#system(target_cmd . " load-buffer %s", [slime#config#resolve("paste_file")])
-    call slime#common#system(target_cmd . " send-keys -X -t %s cancel", [a:config["target_pane"]])
+    call slime#common#system(target_cmd . " load-buffer -", [], chunk)
     if bracketed_paste
       call slime#common#system(target_cmd . " paste-buffer -d -p -t %s", [a:config["target_pane"]])
     else

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -304,11 +304,12 @@ g:slime_target		Set to either "screen" (default), "tmux" or "whimrepl".
 g:slime_no_mappings	Set to non zero value to disable the default mappings.
 
 						*g:slime_paste_file*
-g:slime_paste_file	Required to transfer data from vim to GNU screen or
-			tmux. Set to "$HOME/.slime_paste" by default. Setting
+g:slime_paste_file	Required to transfer data from vim to GNU screen.
+			Set to "$HOME/.slime_paste" by default. Setting
 			this explicitly can work around some occasional
 			portability issues. whimrepl does not require or
 			support this setting.
+
 						*g:slime_preserve_curpos*
 g:slime_preserve_curpos	Set to non zero value to preserve cursor position when
 			sending a line or paragraph. Default is 1.


### PR DESCRIPTION
Removed dependency on `g:slime_paste_file` by using STDIN with `tmux load-buffer`. This used to work in older tmux versions, and it's back in tmux 3.2+.

Advantages
- less steps
- no touching the filesystem (faster, probably)
- no leaving `.slime_paste` file around

It might break _something_, in which case I'll see if when need to support both STDIN _and_ `g:slime_paste_file`