### PR TITLE
Rework screen target

### DIFF
--- a/assets/doc/targets/screen.md
+++ b/assets/doc/targets/screen.md
@@ -7,16 +7,6 @@ By default, [GNU Screen](https://www.gnu.org/software/screen/) is assumed, you d
 let g:slime_target = "screen"
 ```
 
-Because Screen doesn't accept input from STDIN, a file is used to pipe data
-between Vim and Screen. By default this file is set to `$HOME/.slime_paste`.
-The name of the file used can be configured through a variable:
-
-    let g:slime_paste_file = expand("$HOME/.slime_paste")
-    " or maybe...
-    let g:slime_paste_file = tempname()
-
-⚠️  This file is not erased by the plugin and will always contain the last thing you sent over.
-
 When you invoke `vim-slime` for the first time, you will be prompted for more configuration.
 
 screen session name:

--- a/autoload/slime/targets/screen.vim
+++ b/autoload/slime/targets/screen.vim
@@ -8,8 +8,7 @@ function! slime#targets#screen#config() abort
 endfunction
 
 function! slime#targets#screen#send(config, text)
-  call slime#common#write_paste_file(a:text)
-  call slime#common#system('screen -S %s -p %s -X eval "readreg p %s"', [a:config["sessionname"], a:config["windowname"], slime#config#resolve("paste_file")])
+  call slime#common#system('screen -S %s -p %s -X readreg p -', [a:config["sessionname"], a:config["windowname"]], a:text)
   call slime#common#system('screen -S %s -p %s -X paste p', [a:config["sessionname"], a:config["windowname"]])
 endfunction
 

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -304,11 +304,10 @@ g:slime_target		Set to either "screen" (default), "tmux" or "whimrepl".
 g:slime_no_mappings	Set to non zero value to disable the default mappings.
 
 						*g:slime_paste_file*
-g:slime_paste_file	Required to transfer data from vim to GNU screen.
+g:slime_paste_file	Required to transfer data from vim to some targets.
 			Set to "$HOME/.slime_paste" by default. Setting
 			this explicitly can work around some occasional
-			portability issues. whimrepl does not require or
-			support this setting.
+			portability issues.
 
 						*g:slime_preserve_curpos*
 g:slime_preserve_curpos	Set to non zero value to preserve cursor position when


### PR DESCRIPTION
Removed dependency on `g:slime_paste_file` by using STDIN with screen `readreg`.

Advantages

- less steps
- no touching the filesystem (faster, probably)
- no leaving .slime_paste file around

It might break something, in which case I'll see if when need to support both STDIN and `g:slime_paste_file`

related: #431