### PR TITLE
Revert "Skip paste_file for screen target"

### DIFF
--- a/assets/doc/targets/screen.md
+++ b/assets/doc/targets/screen.md
@@ -7,6 +7,16 @@ By default, [GNU Screen](https://www.gnu.org/software/screen/) is assumed, you d
 let g:slime_target = "screen"
 ```
 
+Because Screen doesn't accept input from STDIN, a file is used to pipe data
+between Vim and Screen. By default this file is set to `$HOME/.slime_paste`.
+The name of the file used can be configured through a variable:
+
+    let g:slime_paste_file = expand("$HOME/.slime_paste")
+    " or maybe...
+    let g:slime_paste_file = tempname()
+
+⚠️  This file is not erased by the plugin and will always contain the last thing you sent over.
+
 When you invoke `vim-slime` for the first time, you will be prompted for more configuration.
 
 screen session name:

--- a/autoload/slime/targets/screen.vim
+++ b/autoload/slime/targets/screen.vim
@@ -8,7 +8,8 @@ function! slime#targets#screen#config() abort
 endfunction
 
 function! slime#targets#screen#send(config, text)
-  call slime#common#system('screen -S %s -p %s -X readreg p -', [a:config["sessionname"], a:config["windowname"]], a:text)
+  call slime#common#write_paste_file(a:text)
+  call slime#common#system('screen -S %s -p %s -X eval "readreg p %s"', [a:config["sessionname"], a:config["windowname"], slime#config#resolve("paste_file")])
   call slime#common#system('screen -S %s -p %s -X paste p', [a:config["sessionname"], a:config["windowname"]])
 endfunction
 

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -304,10 +304,11 @@ g:slime_target		Set to either "screen" (default), "tmux" or "whimrepl".
 g:slime_no_mappings	Set to non zero value to disable the default mappings.
 
 						*g:slime_paste_file*
-g:slime_paste_file	Required to transfer data from vim to some targets.
+g:slime_paste_file	Required to transfer data from vim to GNU screen.
 			Set to "$HOME/.slime_paste" by default. Setting
 			this explicitly can work around some occasional
-			portability issues.
+			portability issues. whimrepl does not require or
+			support this setting.
 
 						*g:slime_preserve_curpos*
 g:slime_preserve_curpos	Set to non zero value to preserve cursor position when


### PR DESCRIPTION
This reverts commit aa9371b29f90885d3b832b71c20935c32184a7e9.

I apparently wasn't testing with the branch changes — this doesn't work.