### PR TITLE
Update vim-slime.txt: removed conformed to deprecation

### DIFF
--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -165,7 +165,7 @@ for more configuration.
 
 jobid~
 
-In the neovim terminal buffer type ":echo b:terminal_job_id" to get the
+In the neovim terminal buffer type ":echo &channel" to get the
 job_id for that terminal
 
 ==============================================================================


### PR DESCRIPTION
removed deprecated reference to b:terminal_job_pid

https://neovim.io/doc/user/deprecated.html


I'm a sucker for good/verbose documentation and that's what I aspired to with my contributions to [asset/doc/targets/neovim.md](https://github.com/jpalardy/vim-slime/blob/main/assets/doc/targets/neovim.md)  so a future direction would be to include a reference to it in the `:help` documentation, or incorporate some of it. 