### PR TITLE
small change: don't set b:slime_config in neovim menu configuration

### DIFF
--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -307,8 +307,7 @@ function! s:config_with_menu() abort
   let selection = str2nr(inputlist(menu_strings))
 
   if selection <= 0 || selection >= len(menu_strings)
-    let b:slime_config = {}
-    return
+    return {}
   endif
 
   let used_config = term_bufinfo[selection - 1]


### PR DESCRIPTION
In the Neovim target, return an empty config when an out-of-bounds option is input into config_with_menu rather than setting b:config in buffer.  Tested this. 