### PR TITLE
Use the paste file in conemu for faster turnaround

### DIFF
--- a/autoload/slime/common.vim
+++ b/autoload/slime/common.vim
@@ -25,7 +25,12 @@ function! slime#common#write_paste_file(text)
     call mkdir(paste_dir, "p")
   endif
   let lines = split(a:text, "\n", 1)
-  call writefile(lines, slime#config#resolve("paste_file"), 'b')
+  let paste_file = slime#config#resolve("paste_file")
+  let result = writefile(lines, paste_file, 'bS')
+  if result != 0
+    echoerr "Couldn't write to slime paste file."
+  endif
+  return paste_file
 endfunction
 
 function! slime#common#capitalize(text)

--- a/autoload/slime/targets/conemu.vim
+++ b/autoload/slime/targets/conemu.vim
@@ -9,11 +9,8 @@ function! slime#targets#conemu#config() abort
 endfunction
 
 function! slime#targets#conemu#send(config, text)
-  " use the selection register to send text to ConEmu using the windows clipboard (see help gui-clipboard)
-  " save the current selection to restore it after send
-  let tmp = @*
-  let @* = a:text
-  call slime#common#system("conemuc -guimacro:%s print", [a:config["HWND"]])
-  let @* = tmp
+  " Use the selection register to send text to ConEmu using the slime paste file
+  let paste_file = slime#common#write_paste_file(a:text)
+  call slime#common#system("conemuc -guimacro:%s pastefile 2 %s", [a:config["HWND"], paste_file])
 endfunction
 


### PR DESCRIPTION
This PR changes conemu to use the paste file instead of the windows clipboard. This can make it slightly faster if the clipboard is configured to use a subprocess like powershell.

Changes:

* The `slime#common#write_paste_file` now returns the name of the paste file to which it wrote, so that `slime#resolve#config` doesn't have to be called twice, once in the `conemu#send` and once in the `write_paste_file` method.
* The case where the paste file isn't written is checked.
* The paste file has the `S` flag set, which tells vim not to bother calling `fsync()` on the file, for faster write speeds. This makes sense. The file doesn't contain anything that needs to persist across reboots.
* ConEMU writes to the paste file and uses that instead.

This change has been "tested on my machine" and works.

