### PR TITLE
Improve handling of multibyte characters in tmux target for vim-slime

### DIFF
--- a/autoload/slime/targets/tmux.vim
+++ b/autoload/slime/targets/tmux.vim
@@ -24,8 +24,8 @@ function! slime#targets#tmux#send(config, text)
   " reasonable hardcode, will become config if needed
   let chunk_size = 1000
 
-  for i in range(0, len(text_to_paste) / chunk_size)
-    let chunk = text_to_paste[i * chunk_size : (i + 1) * chunk_size - 1]
+  for i in range(0, strchars(text_to_paste) / chunk_size)
+    let chunk = strcharpart(text_to_paste, i * chunk_size, chunk_size)
     call slime#common#system(target_cmd . " load-buffer -", [], chunk)
     if bracketed_paste
       call slime#common#system(target_cmd . " paste-buffer -d -p -t %s", [a:config["target_pane"]])


### PR DESCRIPTION
Another rather niche bug along the same lines as #444.

This PR updates the tmux target implementation in vim-slime to handle multibyte characters correctly when sending text to tmux. The previous method of slicing the text based on byte coun could lead to broken characters if the text contained multibyte characters. By using `strchars` and `strcharpart`, we ensure that the text is divided based on character count, preserving the 
integrity of multibyte characters.

I encountered this in my setup where I use vim slime to send large texts which contain surrogate utf8 characters (e.g. outputs from other programs) to LLM providers via [gpt-cli](https://github.com/kharvd/gpt-cli).
