### PR TITLE
Shallow-copy default config to buffer variable

### DIFF
--- a/autoload/slime.vim
+++ b/autoload/slime.vim
@@ -35,7 +35,7 @@ function! s:SlimeGetConfig()
   " assume defaults, if they exist
 
   if exists("g:slime_default_config")
-    let b:slime_config = g:slime_default_config
+    let b:slime_config = copy(g:slime_default_config)
     if exists("b:slime_config") && !s:SlimeDispatchValidate("ValidConfig", b:slime_config, 0)
         unlet b:slime_config
     endif


### PR DESCRIPTION
Because assignment in Vimscript copies references, the old behavior causes two buffers to share the same config dictionary object if one sets `g:slime_default_config`. This new behavior guarantees that they create unique copies of the default.