### PR TITLE
Add bracketed-paste support for neovim

### DIFF
--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -193,6 +193,19 @@ local function get_slime_pid()
 end
 ```
 
+### bracketed-paste
+
+Some REPLs can interfere with your text pasting. The [bracketed-paste](https://cirw.in/blog/bracketed-paste) mode exists to allow raw pasting.
+
+`neovim` supports bracketed-paste, use:
+
+```vim
+let g:slime_bracketed_paste = 1
+" or
+let b:slime_bracketed_paste = 1
+```
+
+(It is disabled by default because it can create issues with ipython; see [#265](https://github.com/jpalardy/vim-slime/pull/265)).
 
 ## Automatic Configuration
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -61,7 +61,18 @@ function! slime#targets#neovim#config() abort
 endfunction
 
 function! slime#targets#neovim#send(config, text) abort
-    call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
+  let [bracketed_paste, text_to_paste, has_crlf] = slime#common#bracketed_paste(a:text)
+  let job_id = str2nr(a:config["jobid"])
+  if bracketed_paste
+    call chansend(job_id, "\e[200~")
+    call chansend(job_id, text_to_paste)
+    call chansend(job_id, "\e[201~")
+    if has_crlf
+      call chansend(job_id, "\n")
+    end
+  else
+    call chansend(job_id, split(a:text, "\n", 1))
+  end
 endfunction
 
 function! slime#targets#neovim#SlimeAddChannel(buf_in) abort


### PR DESCRIPTION
Neovim's terminal supports this, so I've added it following the other implementations.