### PR TITLE
Support lazyloading by existing terminals for neovim

### DIFF
--- a/plugin/slime.vim
+++ b/plugin/slime.vim
@@ -40,6 +40,10 @@ endif
 " the channel id of the last opened terminal
 if slime#config#resolve("target") == "neovim"
   if has('nvim')
+    " Add existing buffers (SlimeAddChannel will check if it's a terminal)
+    for buf in getbufinfo()
+      call slime#targets#neovim#SlimeAddChannel(buf.bufnr)
+    endfor
     augroup nvim_slime
       autocmd!
       " keeping track of channels that are open


### PR DESCRIPTION
If this plugin is lazy loaded in response to a keybinding e.g. using lazy.nvim then there can be existing terminals it doesn't know about. This PR just adds the terminals from all existing buffers at startup.

P.S. Thanks a lot for the plugin and being so responsive. Very much appreciated!