### PR TITLE
Inform user about `:%SlimeSend`

### DIFF
--- a/assets/doc/advanced.md
+++ b/assets/doc/advanced.md
@@ -49,6 +49,8 @@ nmap <leader>s <Plug>SlimeMotionSend
 
 "send line
 nmap <leader>ss <Plug>SlimeLineSend
+"send the whole file
+nmap <silent> <leader>sf :%SlimeSend<CR>
 ```
 
 Of course these mappings are just examples; you can set them according to your preference.

--- a/doc/vim-slime.txt
+++ b/doc/vim-slime.txt
@@ -53,8 +53,9 @@ benefits of using Vim (familiar environment, syntax highlighting, persistence
 						*:SlimeSend*
 :<range>SlimeSend	Send a [range] of lines to screen, tmux or whimrepl.
 			If no range is provided the current line is sent.
-
-                                                *:SlimeSend1*
+			To send a whole file try: >
+			:%SlimeSend.
+<                                                *:SlimeSend1*
 :SlimeSend1 {text}      Send a single line of text, specified on the command
                         line, to screen, tmux, or whimrepl. A carriage return
                         is automatically appended.


### PR DESCRIPTION
It's a pretty neat helper.

[Relevant discussion](https://github.com/jpalardy/vim-slime/issues/145#issuecomment-3965726242)

A couple of notes: I'm unfamiliar with writing vimdocs, from what I can tell examples are generally written thusly:

```vimdoc
:<range>SlimeSend	Send a [range] of lines to screen, tmux or whimrepl.
			If no range is provided the current line is sent.
			To send a whole file try: >
			:%SlimeSend.
<                                                *:%SlimeSend1*
:SlimeSend1 {text}      Send a single line of text, specified on the command
```

Although in the original post I had it as `*:%SlimeSend*`

I'd consider also adding it to the [advanced section](https://github.com/jpalardy/vim-slime/blob/main/assets/doc/advanced.md#vim-style-mappings) if the maintainers do not think that that would detract from the concise writing in that page.
Something like:

```vimscript
"send based on motion or text object
nmap <leader>s <Plug>SlimeMotionSend
"send the whole file
nmap <silent> <leader>sf :%SlimeSend<CR>
```